### PR TITLE
Update check_netscaler.pl

### DIFF
--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -259,16 +259,16 @@ sub check_vserver
 			$counter_unkown++;
 			$plugin->add_message(CRITICAL, $state->{name} . " UNKOWN;");				
 		}
-			
-		my ($code, $message) = $plugin->check_messages;
+	}		
+	my ($code, $message) = $plugin->check_messages;
 		
-		my $stats = "[" . $counter_up . " UP, " . 
-		                  $counter_down . " DOWN, " .
-				  $counter_oos . " OOS, " .
-				  $counter_unkown . " UNKOWN" . "]";
+	my $stats = "[" . $counter_up . " UP, " . 
+	                  $counter_down . " DOWN, " .
+			  $counter_oos . " OOS, " .
+			  $counter_unkown . " UNKOWN" . "]";
 				
-		$plugin->nagios_exit($code, $message . " " . $stats);
-	}
+	$plugin->nagios_exit($code, $message . " " . $stats);
+
 }
 
 sub check_string


### PR DESCRIPTION
Noticed that for the vserver sub it reports the status of only the first vserver and then exits. This adjustment makes sure that it loops through all vservers, then reports and exits.