### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 1.2.0 (2017-XX-XX)
-- added command server to check status of Load Balancing Servers
-- added command hwinfo to just print information about the Netscaler itself
-- added command interfaces to check state of all interfaces and add performance data for each interface
-- added command to request performance data
-- added command to check the state of a servicegroup and its members (set warning and critical values for member quorum)
-- added Icinga2 config templates
+## 1.2.0 (2017-08-12)
+- merged pull request from @bb-Ricardo
+  - added command server to check status of Load Balancing Servers
+  - added command hwinfo to just print information about the Netscaler itself
+  - added command interfaces to check state of all interfaces and add performance data for each interface
+  - added command to request performance data
+  - added command to check the state of a servicegroup and its members (set warning and critical values for member quorum)
+  - added Icinga2 config templates
+- updated documentation and plugin_test.sh
 
 ## 1.1.1 (2017-06-10)
 - bugfix for servicegroups in 12.0 (#12)
@@ -22,16 +24,16 @@
  - improved check for ssl certificates to only check for a specific certificate
  - fixed a bug in check_state to support services and servicegroups again
 
-## 0.2.0
+## 0.2.0 2017-01-04
  - patch for Nitro.pm to support ssl connections
  - added check to test the validity and expiry of installed certificates 
 
-## 0.1.2
+## 0.1.2 2016-12-02
  - added performance data feature 
  - updated sub add_arg and added default values for parameters
  - Bugfix in vserver checks loop by @macampo 
 
-## 0.1.1 
+## 0.1.1 2016-11-10
  - documentation fixes by @Velociraptor85
 
 ## 0.1.0 (2015-12-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0 (2017-XX-XX)
+- added command server to check status of Load Balancing Servers
+- added command hwinfo to just print information about the Netscaler itself
+- added command interfaces to check state of all interfaces and add performance data for each interface
+- added command to request performance data
+- added command to check the state of a servicegroup and its members (set warning and critical values for member quorum)
+- added Icinga2 config templates
+
 ## 1.1.1 (2017-06-10)
 - bugfix for servicegroups in 12.0 (#12)
 - new option to connect to an alternate port (for CPX instances)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Currently the plugin has the following subcommands:
 - **sslcert:** check the lifetime for installed ssl certificates
 - **nsconfig:** check for configuration changes which are not saved to disk
 - **staserver:** check if configured STA servers are available
+- **server:** check status of Load Balancing Servers
+- **servicegroup:** check the state of a servicegroup and its members
+- **hwinfo:** just print information about the Netscaler itself
+- **interfaces:** check state of all interfaces and add performance data for each interface
+- **performancedata:** gather performancedata from all sorts of API endpoints
 - **debug:** debug command, print all data for a endpoint
 
 This plugin works with VPX, MPX, SDX and CPX NetScaler Appliances. The api responses may differ by build, appliance type and your installed license.
@@ -108,6 +113,51 @@ If you want to connect to your NetScaler with SSL/HTTPS you should also install 
     # NetScaler::STA::vs_vpn_gateway
     ./check_netscaler.pl -H ${IPADDR} -s -C staserver -n vs_vpn_gateway
 
+## Check if Load Balancer server are working
+
+    # NetScaler::Server
+    ./check_netscaler.pl -H ${IPADDR} -s -C server
+
+## Check status of a service group
+##### define member quorum (in percent) with warning and critical values
+    # NetScaler::Servicegroup::vs_vpn_gateway
+    ./check_netscaler.pl -H ${IPADDR} -s -C servicegroup -n vs_vpn_gateway -w 75 -c 50
+
+## Get information about the netscaler
+
+    # NetScaler::HWInfo
+    ./check_netscaler.pl -H ${IPADDR} -s -C hwinfo
+
+## Check status of all network interfaces
+
+    # NetScaler::Interfaces
+    ./check_netscaler.pl -H ${IPADDR} -s -C interfaces
+
+## Request performance data
+##### all fields must be defined via "-n" option and be seperated with a comma
+
+    # NetScaler::Performancedata on Cache hit/misses
+    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n cachetothits,cachetotmisses
+
+    # NetScaler::Performancedata on tcp connections
+    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n tcpcurclientconn,tcpcurclientconnestablished,tcpcurserverconn,tcpcurserverconnestablished
+
+    # NetScaler::Performancedata on network interfaces
+    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o Interface -n id.totrxbytes
+
+    # NetScaler::Current user sessions
+    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
+
+    # find more object names to check out for object type "ns"
+    /check_netscaler.pl -H ${IPADDR} -s -C debug -o ns
+
+    # more interesting performance data object types
+    * ns
+    * cache
+    * protocolhttp
+    * protocolip
+    * protocoltcp
+
 ## Debug command
     # Print all LB vServers (stat endpoint)
     ./check_netscaler.pl -H ${IPADDR} -s -C debug -o lbvserver
@@ -132,6 +182,14 @@ define command {
 username=nagios
 password=password
 ```
+
+# Authors
+- @slauger
+
+# Contributors
+- @macampo
+- @Velociraptor85
+- @bb-ricardo
 
 # NITRO API Documentation
 

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ password=password
 ```
 
 ## Authors
-- @slauger
+- [slauger](https://github.com/slauger)
 
 ## Contributors
-- @macampo
-- @Velociraptor85
-- @bb-ricardo
+- [macampo](https://github.com/macampo)
+- [Velociraptor85](https://github.com/Velociraptor85)
+- [bb-ricardo](https://github.com/bb-ricardo)
 
 ## NITRO API Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,176 +4,227 @@ A Nagios Plugin written for the Citrix NetScaler Application Delivery Controller
 
 Currently the plugin has the following subcommands:
 
-- **state:** check the current service state of vservers (e.g. lb, vpn, gslb), services and service groups
-- **string, string_not:** check if a string exists in the api response or not (e.g. HA or cluster status)
-- **above, below:** check if a value is above/below a threshold (e.g. traffic limits, concurrent connections)
-- **sslcert:** check the lifetime for installed ssl certificates
-- **nsconfig:** check for configuration changes which are not saved to disk
-- **staserver:** check if configured STA servers are available
-- **server:** check status of Load Balancing Servers
-- **servicegroup:** check the state of a servicegroup and its members
-- **hwinfo:** just print information about the Netscaler itself
-- **interfaces:** check state of all interfaces and add performance data for each interface
-- **performancedata:** gather performancedata from all sorts of API endpoints
-- **debug:** debug command, print all data for a endpoint
+
+| command | description |
+---       | --- | 
+**state**              | check the current service state of vservers (e.g. lb, vpn, gslb), services and service groups
+**string, string_not** | check if a string exists in the api response or not (e.g. HA or cluster status)
+**above, below**       | check if a value is above/below a threshold (e.g. traffic limits, concurrent connections)
+**sslcert**            | check the lifetime for installed ssl certificates
+**nsconfig**           | check for configuration changes which are not saved to disk
+**server**             | check status of Load Balancing Servers
+**staserver**          | check if configured STA (secure ticket authority) servers are available
+**servicegroup**       | check the state of a servicegroup and its members
+**hwinfo**             | just print information about the Netscaler itself
+**interfaces**         | check state of all interfaces and add performance data for each interface
+**performancedata**    | gather performancedata from all sorts of API endpoints
+**debug**              | debug command, print all data for a endpoint
 
 This plugin works with VPX, MPX, SDX and CPX NetScaler Appliances. The api responses may differ by build, appliance type and your installed license.
 
-The plugin supports performance data for the commands state and the above or below threshold checks.
+The plugin supports performance data for the commands state and the above or below threshold checks. Also there is a performancedata command to gather information from your NetScaler.
 
-Feedback and feature requests are appreciated. 
+Example configurations for Nagios and Icinga 2 can be found in the exmaples directory of this repository.
 
-# Installation
+Feedback and feature requests are appreciated. Just create an issue on GitHub or send me a pull request.
+
+## Installation
 
 On a Enterprise Linux machine (CentOS, RHEL) execute the following commands to install all Perl dependencies (Nagios::Plugin, LWP, JSON):
 
-    yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin
+```
+yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin
+```
 
 If you want to connect to your NetScaler with SSL/HTTPS you should also install the LWP HTTPS package.
 
-    yum install perl-LWP-Protocol-https
+```
+yum install perl-LWP-Protocol-https
+```
 
-# Usage Examples
+## Usage Examples
 
-## Check status of vServers
-    # NetScaler::LBvServer
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o lbvserver
+### Check status of vServers
 
-    # NetScaler::LBvServer::Website
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o lbvserver -n vs_lb_http_webserver
+```
+# NetScaler::LBvServer
+./check_netscaler.pl -H ${IPADDR} -s -C state -o lbvserver
 
-    # NetScaler::VPNvServer
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o vpnvserver
+# NetScaler::LBvServer::Website
+./check_netscaler.pl -H ${IPADDR} -s -C state -o lbvserver -n vs_lb_http_webserver
 
-    # NetScaler::GSLBvServer
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o gslbvserver
+# NetScaler::VPNvServer
+./check_netscaler.pl -H ${IPADDR} -s -C state -o vpnvserver
 
-    # NetScaler::AAAvServer
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o authenticationvserver
+# NetScaler::GSLBvServer
+./check_netscaler.pl -H ${IPADDR} -s -C state -o gslbvserver
 
-    # NetScaler::CSvServer
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o csvserver
+# NetScaler::AAAvServer
+./check_netscaler.pl -H ${IPADDR} -s -C state -o authenticationvserver
 
-    # NetScaler::SSLvServer (obsolet and replaced by lbvserver for newer builds)
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o sslvserver
+# NetScaler::CSvServer
+./check_netscaler.pl -H ${IPADDR} -s -C state -o csvserver
 
-## Check status of services
-    # NetScaler::Services
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o service
+# NetScaler::SSLvServer (obsolet and replaced by lbvserver for newer builds)
+./check_netscaler.pl -H ${IPADDR} -s -C state -o sslvserver
+```
 
-    # NetScaler::Services::Webserver
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o service -n svc_webserver
+### Check status of services
 
-## Check status of servicegroups
-    # NetScaler::Servicegroups
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o servicegroup
+```
+# NetScaler::Services
+./check_netscaler.pl -H ${IPADDR} -s -C state -o service
 
-    # NetScaler::Servicegroups::Webservers
-    ./check_netscaler.pl -H ${IPADDR} -s -C state -o servicegroup -n sg_webservers
+# NetScaler::Services::Webserver
+./check_netscaler.pl -H ${IPADDR} -s -C state -o service -n svc_webserver
+```
 
-## Check system health
-    # NetScaler::Memory
-    ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n memusagepcnt -w 75 -c 80
+### Check status of service groups
 
-    # NetScaler::CPU
-    ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n cpuusagepcnt -w 75 -c 80
+```
+# NetScaler::Servicegroups
+./check_netscaler.pl -H ${IPADDR} -s -C state -o servicegroup
 
-    # NetScaler::CPUMGMT
-    ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
+# NetScaler::Servicegroups::Webservers
+./check_netscaler.pl -H ${IPADDR} -s -C state -o servicegroup -n sg_webservers
+```
 
-    # NetScaler::Disk0
-    ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk0perusage -w 75 -c 80
+### Check status of a service group and quorum
 
-    # NetScaler::Disk1
-    ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk1perusage -w 75 -c 80
+define member quorum (in percent) with warning and critical values
 
-## Check high availability status
-    # NetScaler::HA::Status
-    ./check_netscaler.pl -H ${IPADDR} -s -C string_not -o hanode -n hacurstatus -w YES -c YES
+```
+# NetScaler::Servicegroup::Webservers
+./check_netscaler.pl -H ${IPADDR} -s -C servicegroup -n sg_webservers -w 75 -c 50
+```
 
-    # NetScaler::HA::State
-    ./check_netscaler.pl -H ${IPADDR} -s -C string_not -o hanode -n hacurstate -w UP -c UP
+### Check if Load Balancing servers are enabled
 
-## Check expiration of installed ssl certificates
-    # NetScaler::Certs
-    ./check_netscaler.pl -H ${IPADDR} -s -C sslcert -w 30 -c 10
+```
+# NetScaler::Server
+./check_netscaler.pl -H ${IPADDR} -s -C server
 
-    # NetScaler::Certs::Wildcard
-    ./check_netscaler.pl -H ${IPADDR} -s -C sslcert -n wildcard.example.com -w 30 -c 10
+# NetScaler::Server
+./check_netscaler.pl -H ${IPADDR} -s -C server -n web01.example.com
+```
 
-## Check for unsaved configuration changes
-    # NetScaler::Config
-    ./check_netscaler.pl -H ${IPADDR} -s -C nsconfig
+### Check system health
 
-## Check if STA servers are working
+```
+# NetScaler::Memory
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n memusagepcnt -w 75 -c 80
 
-    # NetScaler::STA
-    ./check_netscaler.pl -H ${IPADDR} -s -C staserver
+# NetScaler::CPU
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n cpuusagepcnt -w 75 -c 80
 
-    # NetScaler::STA::vs_vpn_gateway
-    ./check_netscaler.pl -H ${IPADDR} -s -C staserver -n vs_vpn_gateway
+# NetScaler::CPUMGMT
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
 
-## Check if Load Balancer server are working
+# NetScaler::Disk0
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk0perusage -w 75 -c 80
 
-    # NetScaler::Server
-    ./check_netscaler.pl -H ${IPADDR} -s -C server
+# NetScaler::Disk1
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk1perusage -w 75 -c 80
+```
 
-## Check status of a service group
-##### define member quorum (in percent) with warning and critical values
-    # NetScaler::Servicegroup::vs_vpn_gateway
-    ./check_netscaler.pl -H ${IPADDR} -s -C servicegroup -n vs_vpn_gateway -w 75 -c 50
+### Check high availability status
 
-## Get information about the netscaler
+```
+# NetScaler::HA::Status
+./check_netscaler.pl -H ${IPADDR} -s -C string_not -o hanode -n hacurstatus -w YES -c YES
 
-    # NetScaler::HWInfo
-    ./check_netscaler.pl -H ${IPADDR} -s -C hwinfo
+# NetScaler::HA::State
+./check_netscaler.pl -H ${IPADDR} -s -C string_not -o hanode -n hacurstate -w UP -c UP
+```
 
-## Check status of all network interfaces
+### Check expiration of installed ssl certificates
 
-    # NetScaler::Interfaces
-    ./check_netscaler.pl -H ${IPADDR} -s -C interfaces
+```
+# NetScaler::Certs
+./check_netscaler.pl -H ${IPADDR} -s -C sslcert -w 30 -c 10
 
-## Request performance data
-##### all fields must be defined via "-n" option and be seperated with a comma
+# NetScaler::Certs::Wildcard
+./check_netscaler.pl -H ${IPADDR} -s -C sslcert -n wildcard.example.com -w 30 -c 10
+```
 
-    # NetScaler::Performancedata on Cache hit/misses
-    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n cachetothits,cachetotmisses
+### Check for unsaved configuration changes
 
-    # NetScaler::Performancedata on tcp connections
-    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n tcpcurclientconn,tcpcurclientconnestablished,tcpcurserverconn,tcpcurserverconnestablished
+```
+# NetScaler::Config
+./check_netscaler.pl -H ${IPADDR} -s -C nsconfig
+```
 
-    # NetScaler::Performancedata on network interfaces
-    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o Interface -n id.totrxbytes
+### Check if STA servers are working
 
-    # NetScaler::Current user sessions
-    ./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
+```
+# NetScaler::STA
+./check_netscaler.pl -H ${IPADDR} -s -C staserver
 
-    # find more object names to check out for object type "ns"
-    /check_netscaler.pl -H ${IPADDR} -s -C debug -o ns
+# NetScaler::STA::vs_vpn_gateway
+./check_netscaler.pl -H ${IPADDR} -s -C staserver -n vs_vpn_gateway
+```
 
-    # more interesting performance data object types
-    * ns
-    * cache
-    * protocolhttp
-    * protocolip
-    * protocoltcp
+### Get information about the netscaler
+
+```
+# NetScaler::HWInfo
+./check_netscaler.pl -H ${IPADDR} -s -C hwinfo
+```
+
+### Check status of all network interfaces
+
+```
+# NetScaler::Interfaces
+./check_netscaler.pl -H ${IPADDR} -s -C interfaces
+```
+
+### Request performance data
+
+All fields must be defined via "-n" option and be seperated with a comma.
+
+```
+# NetScaler::Performancedata on Cache hit/misses
+./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n cachetothits,cachetotmisses
+
+# NetScaler::Performancedata on tcp connections
+./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n tcpcurclientconn,tcpcurclientconnestablished,tcpcurserverconn,tcpcurserverconnestablished
+
+# NetScaler::Performancedata on network interfaces
+./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o Interface -n id.totrxbytes
+
+# NetScaler::Current user sessions
+./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
+
+# find more object names to check out for object type "ns"
+/check_netscaler.pl -H ${IPADDR} -s -C debug -o ns
+```
+
+For more interesting performance data object types see the following API methods.
+
+- ns
+- cache
+- protocolhttp
+- protocolip
+- protocoltcp
 
 ## Debug command
-    # Print all LB vServers (stat endpoint)
-    ./check_netscaler.pl -H ${IPADDR} -s -C debug -o lbvserver
 
-    # Print all LB vServers (config endpoint)
-    ./check_netscaler.pl -H ${IPADDR} -s -C debug -o lbvserver -e config
+```
+# Print all LB vServers (stat endpoint)
+./check_netscaler.pl -H ${IPADDR} -s -C debug -o lbvserver
 
-# Configuration File
+# Print all LB vServers (config endpoint)
+./check_netscaler.pl -H ${IPADDR} -s -C debug -o lbvserver -e config
+```
+
+## Configuration File
+
 The plugin uses the Nagios::Plugin Libary, so you can use --extra-opts and seperate the login crendetials from your nagios configuration.
-
-e.g.
 
 ```
 define command {
   command_name check_netscaler_vserver
-  command_line $USER5$/3rdparty/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C check_vserver -I '$ARG1$'
+  command_line $USER5$/3rdparty/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ -s --extra-opts=netscaler@$USER11$/plugins.ini -C state -n '$ARG1$'
 }
 ```
 
@@ -183,20 +234,24 @@ username=nagios
 password=password
 ```
 
-# Authors
+## Authors
 - @slauger
 
-# Contributors
+## Contributors
 - @macampo
 - @Velociraptor85
 - @bb-ricardo
 
-# NITRO API Documentation
+## NITRO API Documentation
 
 You will find a full documentation about the NITRO API on your NetScaler Appliance in the "Download" area.
 
 http://NSIP/nitro-rest.tgz (where NSIP is the IP address of your NetScaler appliance).
 
-# Tested Firmware
+## Tested Firmware
 
 Tested with NetScaler 10.5, 11.0, 11.1 and 12.0. The plugin should work with all available firmware builds.
+
+## Changelog
+
+See [CHANGELOG](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ yum install perl-LWP-Protocol-https
 ./check_netscaler.pl -H ${IPADDR} -s -C state -o servicegroup -n sg_webservers
 ```
 
-### Check status of a service group and quorum
+### Check status and quorum of a service group
 
 define member quorum (in percent) with warning and critical values
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This plugin works with VPX, MPX, SDX and CPX NetScaler Appliances. The api respo
 
 The plugin supports performance data for the commands state and the above or below threshold checks. Also there is a performancedata command to gather information from your NetScaler.
 
-Example configurations for Nagios and Icinga 2 can be found in the exmaples directory of this repository.
+Example configurations for Nagios and Icinga 2 can be found in the examples directory of this repository.
 
 Feedback and feature requests are appreciated. Just create an issue on GitHub or send me a pull request.
 

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -6,7 +6,7 @@
 #
 # https://github.com/slauger/check_netscaler
 #
-# Version: 1.2.0 (2017-XX-XX)
+# Version: 1.2.0 (2017-08-12)
 #
 # Copyright 2015-2017 Simon Lauger
 #
@@ -35,8 +35,8 @@ use Nagios::Plugin;
 my $plugin = Nagios::Plugin->new(
 	plugin		=> 'check_netscaler',
 	shortname	=> 'NetScaler',
-	version		=> '1.2.X',
-	url			=> 'https://github.com/slauger/check_netscaler',
+	version		=> '1.2.0',
+	url		=> 'https://github.com/slauger/check_netscaler',
 	blurb		=> 'Nagios Plugin for Citrix NetScaler Appliance (VPX/MPX/SDX/CPX)',
 	usage		=> 'Usage: %s -H <hostname> [ -u <username> ] [ -p <password> ]
 -C <command> [ -o <objecttype> ] [ -n <objectname> ] [ -e <endpoint> ]
@@ -147,10 +147,10 @@ if ($plugin->opts->command eq 'state') {
 	check_threshold($plugin, $plugin->opts->command);
 } elsif ($plugin->opts->command eq 'string') {
 	# check if a response does contains a specific string
-	check_string($plugin, "matches");
+	check_string($plugin, 'matches');
 } elsif ($plugin->opts->command eq 'string_not') {
 	# check if a response does not contains a specific string
-	check_string($plugin, "matches not");
+	check_string($plugin, 'matches not');
 } elsif ($plugin->opts->command eq 'sslcert') {
 	# check for the lifetime of installed certificates
 	check_sslcert($plugin);
@@ -258,7 +258,7 @@ sub nitro_client {
 	}
 
 	if ($plugin->opts->verbose) {
-		print "debug: target url is " . $url . "\n";
+		print "debug: target url is $url\n";
 	}
 
 	my $request = HTTP::Request->new(GET => $url);
@@ -401,7 +401,7 @@ sub check_string
 		$plugin->nagios_die('command requires parameter for warning and critical');
 	}
 
-	if ($type_of_string_comparison ne "matches" && $type_of_string_comparison ne "matches not") {
+	if ($type_of_string_comparison ne 'matches' && $type_of_string_comparison ne 'matches not') {
 		$plugin->nagios_die('string can only be checked for "matches" and "matches not"');
 	}
 
@@ -414,9 +414,9 @@ sub check_string
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$plugin->opts->objecttype};
 
-	if (($type_of_string_comparison eq "matches" && $response->{$plugin->opts->objectname} eq $plugin->opts->critical) || ($type_of_string_comparison eq "matches not" && $response->{$plugin->opts->objectname} ne $plugin->opts->critical)) {
+	if (($type_of_string_comparison eq 'matches' && $response->{$plugin->opts->objectname} eq $plugin->opts->critical) || ($type_of_string_comparison eq 'matches not' && $response->{$plugin->opts->objectname} ne $plugin->opts->critical)) {
 		$plugin->nagios_exit(CRITICAL, $plugin->opts->objecttype . '::' . $plugin->opts->objectname . ' ' . $type_of_string_comparison . ' keyword (current: ' . $response->{$plugin->opts->objectname} . ', critical: ' . $plugin->opts->critical . ')');
-	} elsif (($type_of_string_comparison eq "matches" && $response->{$plugin->opts->objectname} eq $plugin->opts->warning) || ($type_of_string_comparison eq "matches not" && $response->{$plugin->opts->objectname} ne $plugin->opts->warning)) {
+	} elsif (($type_of_string_comparison eq 'matches' && $response->{$plugin->opts->objectname} eq $plugin->opts->warning) || ($type_of_string_comparison eq 'matches not' && $response->{$plugin->opts->objectname} ne $plugin->opts->warning)) {
 		$plugin->nagios_exit(WARNING, $plugin->opts->objecttype . '::' . $plugin->opts->objectname . ' ' . $type_of_string_comparison . ' keyword (current: ' . $response->{$plugin->opts->objectname} . ', warning: ' . $plugin->opts->warning . ')');
 	} else {
 		$plugin->nagios_exit(OK, $plugin->opts->objecttype . '::' . $plugin->opts->objectname . ' OK ('.$response->{$plugin->opts->objectname}.')');
@@ -440,7 +440,7 @@ sub check_threshold
 		$plugin->nagios_die('command requires parameter for warning and critical');
 	}
 
-	if ($direction ne "above" && $direction ne "below") {
+	if ($direction ne 'above' && $direction ne 'below') {
 		$plugin->nagios_die('threshold can only be checked for "above" and "below"');
 	}
 
@@ -463,9 +463,9 @@ sub check_threshold
 		critical => $plugin->opts->critical,
 	);
 
-	if (($direction eq "above" && $response->{$plugin->opts->objectname} >= $plugin->opts->critical) || ($direction eq "below" && $response->{$plugin->opts->objectname} <= $plugin->opts->critical)) {
+	if (($direction eq 'above' && $response->{$plugin->opts->objectname} >= $plugin->opts->critical) || ($direction eq 'below' && $response->{$plugin->opts->objectname} <= $plugin->opts->critical)) {
 		$plugin->nagios_exit(CRITICAL, $plugin->opts->objecttype . '::' . $plugin->opts->objectname . ' is ' . $direction . ' threshold (current: ' . $response->{$plugin->opts->objectname} . ', critical: ' . $plugin->opts->critical . ')');
-	} elsif (($direction eq "above" && $response->{$plugin->opts->objectname} >= $plugin->opts->warning) || ($direction eq "below" && $response->{$plugin->opts->objectname} <= $plugin->opts->warning)) {
+	} elsif (($direction eq 'above' && $response->{$plugin->opts->objectname} >= $plugin->opts->warning) || ($direction eq 'below' && $response->{$plugin->opts->objectname} <= $plugin->opts->warning)) {
 		$plugin->nagios_exit(WARNING, $plugin->opts->objecttype . '::' . $plugin->opts->objectname . ' is ' . $direction . ' threshold (current: ' . $response->{$plugin->opts->objectname} . ', warning: ' . $plugin->opts->warning . ')');
 	} else {
 		$plugin->nagios_exit(OK, $plugin->opts->objecttype . '::' . $plugin->opts->objectname . ' OK ('.$response->{$plugin->opts->objectname}.')');
@@ -539,7 +539,7 @@ sub check_staserver
 
 	my ($code, $message) = $plugin->check_messages;
 
-	if ( $critical == 1) { $code = CRITICAL ; }
+	if ( $critical == 1) { $code = CRITICAL; }
 
 	$plugin->nagios_exit($code, 'server ' . $message);
 }
@@ -552,15 +552,15 @@ sub check_server
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'config';
 	$params{'objectname'} = $plugin->opts->objectname || '';
 	$params{'options'}    = undef;
-	$params{'objecttype'} = "server";
+	$params{'objecttype'} = 'server';
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
 
-	# return critical if all staservers are down at once
+	# return critical if all servers are disabled at once
 	my $critical = 1;
 
-	# check if any stas are in down state
+	# check if any server is in disabled state
 	foreach $response (@{$response}) {
 		if ($response->{'state'} ne 'ENABLED') {
 			$plugin->add_message(WARNING, $response->{'name'} . '('. $response->{'ipaddress'} .') ' . $response->{'state'} . ' ;');
@@ -572,7 +572,7 @@ sub check_server
 
 	my ($code, $message) = $plugin->check_messages;
 
-	if ( $critical == 1) { $code = CRITICAL ; }
+	if ( $critical == 1) { $code = CRITICAL; }
 
 	$plugin->nagios_exit($code, 'server ' . $message);
 }
@@ -610,17 +610,17 @@ sub get_hardware_info
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
 
-	$plugin->add_message(OK, "Platform: " . $response->{'hwdescription'} . ' ' . $response->{'sysid'} . ';');
-	$plugin->add_message(OK, "Manufactured on: " . $response->{'manufactureyear'} . '/' . $response->{'manufacturemonth'} . '/' . $response->{'manufactureday'} . ';');
-	$plugin->add_message(OK, "CPU: " . $response->{'cpufrequncy'} . 'MHz;');
-	$plugin->add_message(OK, "Serial no: " . $response->{'serialno'} . ';');
+	$plugin->add_message(OK, 'Platform: ' . $response->{'hwdescription'} . ' ' . $response->{'sysid'} . ';');
+	$plugin->add_message(OK, 'Manufactured on: ' . $response->{'manufactureyear'} . '/' . $response->{'manufacturemonth'} . '/' . $response->{'manufactureday'} . ';');
+	$plugin->add_message(OK, 'CPU: ' . $response->{'cpufrequncy'} . 'MHz;');
+	$plugin->add_message(OK, 'Serial no: ' . $response->{'serialno'} . ';');
 
 	$params{'objecttype'} = 'nsversion';
 
 	$response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
 
-	$plugin->add_message(OK, "Build Version: " . $response->{'version'} . ';');
+	$plugin->add_message(OK, 'Build Version: ' . $response->{'version'} . ';');
 
 	my ($code, $message) = $plugin->check_messages;
 	$plugin->nagios_exit($code, 'INFO: ' . $message);
@@ -636,17 +636,17 @@ sub get_performancedata
 	$params{'objectname'} = undef;
 	$params{'options'}    = undef;
 
-	if (not defined ($plugin->opts->objectname)) {
-		$plugin->nagios_die('performancedata: no object name(s) "-n" set');
+	if (!defined $plugin->opts->objectname) {
+		$plugin->nagios_die('performancedata: command requires parameter for objectname');
 	}
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
 
-	if ( ref $response eq "ARRAY" ) {
+	if ( ref $response eq 'ARRAY' ) {
 		foreach $response (@{$response}) {
-			foreach my $objectname (split(",",$plugin->opts->objectname)) {
-				if (not index($objectname, ".") != -1) {
+			foreach my $objectname (split(',', $plugin->opts->objectname)) {
+				if (not index($objectname, '.') != -1) {
 					$plugin->nagios_die('performancedata: return data is an array and contains multible objects. You need te seperate id and name with a ".".');
 				}
 
@@ -659,10 +659,10 @@ sub get_performancedata
 					$plugin->nagios_die('performancedata: object name "' . $objectname_name . '" not found in output.');
 				}
 
-				$plugin->add_message(OK, $params{'objecttype'} . "." . $response->{$objectname_id} . "." . $objectname_name . ":" . $response->{$objectname_name} . ",");
+				$plugin->add_message(OK, $params{'objecttype'} . '.' . $response->{$objectname_id} . '.' . $objectname_name . ":" . $response->{$objectname_name} . ",");
 
 				$plugin->add_perfdata(
-					label    => "'" . $params{'objecttype'} . "." . $response->{$objectname_id} . "." . $objectname_name . "'",
+					label    => "'" . $params{'objecttype'} . '.' . $response->{$objectname_id} . '.' . $objectname_name . "'",
 					value    => $response->{$objectname_name},
 					min      => undef,
 					max      => undef,
@@ -671,15 +671,15 @@ sub get_performancedata
 				);
 			}
 		}
-	} elsif ( ref $response eq "HASH" ) {
-		foreach my $objectname (split(",",$plugin->opts->objectname)) {
+	} elsif ( ref $response eq 'HASH' ) {
+		foreach my $objectname (split(',', $plugin->opts->objectname)) {
 			if (not defined($response->{$objectname})) {
 				$plugin->nagios_die('performancedata: object name "' . $objectname . '" not found in output.');
 			}
-			$plugin->add_message(OK, $params{'objecttype'} . "." . $objectname .":", $response->{$objectname}. ",");
+			$plugin->add_message(OK, $params{'objecttype'} . '.' . $objectname . ':', $response->{$objectname}. ',');
 
 			$plugin->add_perfdata(
-				label    => "'" . $params{'objecttype'} . "." . $objectname . "'",
+				label    => "'" . $params{'objecttype'} . '.' . $objectname . "'",
 				value    => $response->{$objectname},
 				min      => undef,
 				max      => undef,
@@ -712,45 +712,45 @@ sub check_interfaces
 
 		my $interface_state = OK;
 
-		my $interface_speed = "N/A";
+		my $interface_speed = 'N/A';
 		if ($interface->{'actspeed'}) { $interface_speed = $interface->{'actspeed'}; }
 
 		if ($interface->{'linkstate'} != 1 ) {
-			push(@interface_errors, "interface " . $interface->{'devicename'} . " has linkstate \"DOWN\"");
+			push(@interface_errors, 'interface ' . $interface->{'devicename'} . " has linkstate \"DOWN\"");
 			$interface_state = CRITICAL;
 		}
 		if ($interface->{'intfstate'} != 1 ) {
-			push(@interface_errors, "interface " . $interface->{'devicename'} . " has intstate \"DOWN\"");
+			push(@interface_errors, 'interface ' . $interface->{'devicename'} . " has intstate \"DOWN\"");
 			$interface_state = CRITICAL;
 		}
-		if ($interface->{'state'} ne "ENABLED" ) {
-			push(@interface_errors, "interface " . $interface->{'devicename'} . " has state \"".$interface->{'state'}."\"");
+		if ($interface->{'state'} ne 'ENABLED' ) {
+			push(@interface_errors, 'interface ' . $interface->{'devicename'} . " has state \"".$interface->{'state'}."\"");
 			$interface_state = CRITICAL;
 		}
 
-		$plugin->add_message($interface_state, "device: " . $interface->{'devicename'} . ' (speed: ' . $interface_speed . ', MTU: ' . $interface->{'actualmtu'} . ', VLAN: ' . $interface->{'vlan'} . ', type: ' . $interface->{'intftype'} . ') ' . $interface->{'state'} . ';');
+		$plugin->add_message($interface_state, 'device: ' . $interface->{'devicename'} . ' (speed: ' . $interface_speed . ', MTU: ' . $interface->{'actualmtu'} . ', VLAN: ' . $interface->{'vlan'} . ', type: ' . $interface->{'intftype'} . ') ' . $interface->{'state'} . ';');
 
 		$plugin->add_perfdata(
 			label    => "\'".$interface->{'devicename'} . ".rxbytes'",
-			value    => $interface->{'rxbytes'}."B"
+			value    => $interface->{'rxbytes'}.'B'
 		);
 		$plugin->add_perfdata(
 			label    => "\'".$interface->{'devicename'} . ".txbytes'",
-			value    => $interface->{'txbytes'}."B"
+			value    => $interface->{'txbytes'}.'B'
 		);
 		$plugin->add_perfdata(
 			label    => "\'".$interface->{'devicename'} . ".rxerrors'",
-			value    => $interface->{'rxerrors'}."c"
+			value    => $interface->{'rxerrors'}.'c'
 		);
 		$plugin->add_perfdata(
 			label    => "\'".$interface->{'devicename'} . ".txerrors'",
-			value    => $interface->{'txerrors'}."c"
+			value    => $interface->{'txerrors'}.'c'
 		);
 	}
 
 	my ($code, $message) = $plugin->check_messages;
 	if (scalar @interface_errors != 0 ) {
-		$message = join(", ",@interface_errors). " - ". $message
+		$message = join(', ', @interface_errors). ' - '. $message
 	}
 	$plugin->nagios_exit($code, 'Interfaces: ' . $message);
 }
@@ -761,8 +761,8 @@ sub check_servicegroup
 	my @servicegroup_errors;
 
 	# define quorum (in percent) of working servicegroup members
-	my $member_quorum_warning = $plugin->opts->warning || "90";
-	my $member_quorum_critical = $plugin->opts->critical || "50";
+	my $member_quorum_warning = $plugin->opts->warning || '90';
+	my $member_quorum_critical = $plugin->opts->critical || '50';
 
 	my %member_state;
 
@@ -777,14 +777,14 @@ sub check_servicegroup
 	}
 
 	my %healthy_servicegroup_states;
-	$healthy_servicegroup_states{"state"} = "ENABLED";
-	$healthy_servicegroup_states{"servicegroupeffectivestate"} = "UP";
-	$healthy_servicegroup_states{"monstate"} = "ENABLED";
-	$healthy_servicegroup_states{"healthmonitor"} = "YES";
+	$healthy_servicegroup_states{'state'} = 'ENABLED';
+	$healthy_servicegroup_states{'servicegroupeffectivestate'} = 'UP';
+	$healthy_servicegroup_states{'monstate'} = 'ENABLED';
+	$healthy_servicegroup_states{'healthmonitor'} = 'YES';
 
 	my %healthy_servicegroup_member_states;
-	$healthy_servicegroup_member_states{"state"} = "ENABLED";
-	$healthy_servicegroup_member_states{"svrstate"} = "UP";
+	$healthy_servicegroup_member_states{'state'} = 'ENABLED';
+	$healthy_servicegroup_member_states{'svrstate'} = 'UP';
 
 	my $response = nitro_client($plugin, \%params);
 	my $servicegroup_response = $response->{$params{'objecttype'}};
@@ -796,7 +796,7 @@ sub check_servicegroup
 		foreach my $servicegroup_check_key ( keys %healthy_servicegroup_states ) {
 
 			if ($servicegroup_response->{$servicegroup_check_key} ne $healthy_servicegroup_states{$servicegroup_check_key}) {
-				push(@servicegroup_errors, 'servicegroup ' . $servicegroup_response->{"servicegroupname"} . ' "'. $servicegroup_check_key . '" is: '. $healthy_servicegroup_states{$servicegroup_check_key});
+				push(@servicegroup_errors, 'servicegroup ' . $servicegroup_response->{'servicegroupname'} . ' "'. $servicegroup_check_key . '" is: '. $healthy_servicegroup_states{$servicegroup_check_key});
 			}
 		}
 		$plugin->add_message(OK, $servicegroup_response->{'servicegroupname'} . ' (' . $servicegroup_response->{'servicetype'} . ') - state: ' . $servicegroup_response->{'servicegroupeffectivestate'} . ' -');
@@ -814,12 +814,12 @@ sub check_servicegroup
 		foreach my $servicegroup_members_check_key ( keys %healthy_servicegroup_member_states ) {
 
 			if ($servicegroup_members_response->{$servicegroup_members_check_key} ne $healthy_servicegroup_member_states{$servicegroup_members_check_key}) {
-				push(@servicegroup_errors, 'servicegroup member ' . $servicegroup_members_response->{"servername"} . ' "'. $servicegroup_members_check_key . '" is '. $healthy_servicegroup_member_states{$servicegroup_members_check_key});
-				$member_state{$servicegroup_members_response->{"servername"}} = "DOWN";
+				push(@servicegroup_errors, 'servicegroup member ' . $servicegroup_members_response->{'servername'} . ' "'. $servicegroup_members_check_key . '" is '. $healthy_servicegroup_member_states{$servicegroup_members_check_key});
+				$member_state{$servicegroup_members_response->{'servername'}} = 'DOWN';
 			}
 		}
-		if (not defined $member_state{$servicegroup_members_response->{"servername"}}) {
-			$member_state{$servicegroup_members_response->{"servername"}} = "UP";
+		if (not defined $member_state{$servicegroup_members_response->{'servername'}}) {
+			$member_state{$servicegroup_members_response->{'servername'}} = "UP";
 		}
 		$plugin->add_message(OK, $servicegroup_members_response->{'servername'} . ' (' . $servicegroup_members_response->{'ip'}.':'. $servicegroup_members_response->{'port'} . ') is ' . $servicegroup_members_response->{'svrstate'} .',');
 	}
@@ -828,7 +828,7 @@ sub check_servicegroup
 	my $members_up = 0;
 	my $members_down = 0;
 	foreach my $member_state_key ( keys %member_state ) {
-		if ($member_state{$member_state_key} eq "DOWN") {
+		if ($member_state{$member_state_key} eq 'DOWN') {
 			$members_down++;
 		} else {
 			$members_up++;
@@ -836,7 +836,7 @@ sub check_servicegroup
 	}
 
 	# check quorum
-	my $member_quorum = sprintf("%1.2f", 100 / ( $members_up + $members_down ) * $members_up);
+	my $member_quorum = sprintf('%1.2f', 100 / ( $members_up + $members_down ) * $members_up);
 
 	if ($member_quorum <= $member_quorum_critical) {
 		$servicegroup_state = CRITICAL;
@@ -844,11 +844,11 @@ sub check_servicegroup
 		$servicegroup_state = WARNING;
 	}
 
-	$plugin->add_message(OK, "member quorum: " . $member_quorum . "% (UP/DOWN): " . $members_up . "/" . $members_down);
+	$plugin->add_message(OK, 'member quorum: ' . $member_quorum . '% (UP/DOWN): ' . $members_up . '/' . $members_down);
 
 	$plugin->add_perfdata(
 		label    => "'" . $plugin->opts->objectname . ".member_quorum'",
-		value    => $member_quorum."%",
+		value    => $member_quorum.'%',
 		min      => 0,
 		max      => 100,
 		warning  => $member_quorum_warning,
@@ -857,7 +857,7 @@ sub check_servicegroup
 
 	my ($code, $message) = $plugin->check_messages;
 	if (scalar @servicegroup_errors != 0 ) {
-		$message = join(", ",@servicegroup_errors). " - ". $message
+		$message = join(', ', @servicegroup_errors). ' - '. $message
 	}
 	$plugin->nagios_exit($servicegroup_state, 'servicegroup: ' . $message);
 }

--- a/examples/icinga2_command.conf
+++ b/examples/icinga2_command.conf
@@ -1,0 +1,23 @@
+object CheckCommand "netscaler" {
+        import "plugin-check-command"
+
+        command = [ PluginDir + "/check_netscaler.pl" ]
+
+        arguments = {
+		"-H" = "$address$"
+		"-u" = "$netscaler_user$"
+		"-p" = "$netscaler_password$"
+		"--ssl" = {
+                        set_if = "$netscaler_ssl$"
+                }
+		"-P" = "$netscaler_port$"
+		"-C" = "$netscaler_command$"
+		"-o" = "$netscaler_objecttype$"
+		"-n" = "$netscaler_objectname$"
+		"-e" = "$netscaler_endpoint$"
+		"-w" = "$warning$"
+		"-c" = "$critical$"
+		"-t" = "$netscaler_timeout$"
+	}
+
+}

--- a/examples/icinga2_service_definitions.conf
+++ b/examples/icinga2_service_definitions.conf
@@ -1,0 +1,139 @@
+/*******************************
+	NetScaler Checks
+*******************************/
+template Service "netscaler_env_details" {
+
+	vars.netscaler_user = "icinga"
+	vars.netscaler_password = "super_secret"
+	vars.netscaler_ssl = true
+}
+
+apply Service "CPU" {
+	import "netscaler_cpu_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Mgmt CPU" {
+	import "netscaler_mgmtcpu_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "MEM" {
+	import "netscaler_mem_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Disk 0" {
+	import "netscaler_disk0_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Disk 1" {
+	import "netscaler_disk1_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "HA Status" {
+	import "netscaler_ha_status_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "HA State" {
+	import "netscaler_ha_state_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Config Status" {
+	import "netscaler_config_status_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "HW Info" {
+	import "netscaler_hwinfo_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Interfaces" {
+	import "netscaler_interfaces_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Load Balanced server status" {
+	import "netscaler_server_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "STA Status " for (vpnverver in [ "my_vpnvserver" ] ) {
+	import "netscaler_staserver_template"
+	import "netscaler_env_details"
+
+	vars.netscaler_objectname = vpnverver
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "VPNV Status " for (vpnverver in [ "my_vpnvserver_a"  ] ) {
+	import "netscaler_vpnvserver_template"
+	import "netscaler_env_details"
+
+	vars.netscaler_objectname = vpnverver
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "LB Status " for (lbvserver in [ "my_lbvserver_a", "my_lbvserver_b" ] ) {
+	import "netscaler_lbvserver_template"
+	import "netscaler_env_details"
+
+	vars.netscaler_objectname = lbvserver
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Servicegroup Status " for (servicegroup in [ "my_servicegroup_a", "my_servicegroup_b" ] ) {
+	import "netscaler_servicegroup_template"
+	import "netscaler_env_details"
+
+	vars.netscaler_objectname = servicegroup
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+// Perfdata
+apply Service "Perf Ctirix Sessions" {
+	import "netscaler_performancedata_template"
+	import "netscaler_env_details"
+
+	vars.netscaler_objecttype = "aaa"
+	vars.netscaler_objectname = "aaacuricasessions,aaacuricaonlyconn"
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+apply Service "Perf TCP connections" {
+	import "netscaler_performancedata_template"
+	import "netscaler_env_details"
+
+	vars.netscaler_objecttype = "ns"
+	vars.netscaler_objectname = "tcpcurclientconn,tcpcurclientconnestablished,tcpcurserverconn,tcpcurserverconnestablished"
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
+/* EOF */

--- a/examples/icinga2_service_templates.conf
+++ b/examples/icinga2_service_templates.conf
@@ -1,0 +1,188 @@
+/*
+ *	service templates for check_netscaler.pl
+ */
+
+// Health Checks
+template Service "netscaler_cpu_template" {
+	import "generic-service"
+	import "perf_enabled"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "above"
+	vars.netscaler_objecttype = "system"
+	vars.netscaler_objectname = "cpuusagepcnt"
+
+	vars.warning = 75
+	vars.critical = 80
+}
+
+template Service "netscaler_mem_template" {
+	import "generic-service"
+	import "perf_enabled"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "above"
+	vars.netscaler_objecttype = "system"
+	vars.netscaler_objectname = "memusagepcnt"
+
+	vars.warning = 75
+	vars.critical = 80
+}
+
+template Service "netscaler_mgmtcpu_template" {
+	import "generic-service"
+	import "perf_enabled"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "above"
+	vars.netscaler_objecttype = "system"
+	vars.netscaler_objectname = "mgmtcpuusagepcnt"
+
+	vars.warning = 75
+	vars.critical = 80
+}
+
+template Service "netscaler_disk0_template" {
+	import "generic-service"
+	import "perf_enabled"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "above"
+	vars.netscaler_objecttype = "system"
+	vars.netscaler_objectname = "disk0perusage"
+
+	vars.warning = 75
+	vars.critical = 80
+}
+
+template Service "netscaler_disk1_template" {
+	import "generic-service"
+	import "perf_enabled"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "above"
+	vars.netscaler_objecttype = "system"
+	vars.netscaler_objectname = "disk1perusage"
+
+	vars.warning = 75
+	vars.critical = 80
+}
+
+// HA Status
+template Service "netscaler_ha_status_template" {
+	import "generic-service"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "string_not"
+	vars.netscaler_objecttype = "hanode"
+	vars.netscaler_objectname = "hacurstatus"
+
+	vars.warning = "YES"
+	vars.critical = "YES"
+}
+
+template Service "netscaler_ha_state_template" {
+	import "generic-service"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "string_not"
+	vars.netscaler_objecttype = "hanode"
+	vars.netscaler_objectname = "hacurstate"
+
+	vars.warning = "UP"
+	vars.critical = "UP"
+}
+
+// Config Changes
+template Service "netscaler_config_status_template" {
+	import "generic-service"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "nsconfig"
+}
+
+// Netscaler info
+template Service "netscaler_hwinfo_template" {
+	import "generic-service"
+	
+	check_command = "netscaler"
+
+	vars.netscaler_command = "hwinfo"
+}
+
+// Interfaces status
+template Service "netscaler_interfaces_template" {
+	import "generic-service"
+	import "perf_enabled"
+	
+	check_command = "netscaler"
+
+	vars.netscaler_command = "interfaces"
+}
+
+// Server Status
+template Service "netscaler_staserver_template" {
+	import "generic-service"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "staserver"
+}
+
+template Service "netscaler_server_template" {
+	import "generic-service"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "server"
+}
+
+template Service "netscaler_lbvserver_template" {
+	import "generic-service"
+	import "perf_enabled"
+	
+	check_command = "netscaler"
+
+	vars.netscaler_command = "state"
+	vars.netscaler_objecttype = "lbvserver"
+}
+
+template Service "netscaler_vpnvserver_template" {
+	import "generic-service"
+	import "perf_enabled"
+	
+	check_command = "netscaler"
+
+	vars.netscaler_command = "state"
+	vars.netscaler_objecttype = "vpnvserver"
+}
+
+// Servicegroup status
+template Service "netscaler_servicegroup_template" {
+	import "generic-service"
+	import "perf_enabled"
+	
+	check_command = "netscaler"
+
+	vars.netscaler_command = "servicegroup"
+}
+
+// Performancedata
+template Service "netscaler_performancedata_template" {
+	import "generic-service"
+	import "perf_enabled"
+	
+	check_command = "netscaler"
+
+	vars.netscaler_command = "performancedata"
+}
+
+// EOF

--- a/examples/plugin_test.sh
+++ b/examples/plugin_test.sh
@@ -40,47 +40,80 @@ else
 	PORT="-P ${5}"
 fi
 
-# NetScaler::SSLCerts
+echo NetScaler::SSLCerts
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C sslcert -w 30 -c 10
+echo
 
-# NetScaler::NSConfig
+echo NetScaler::NSConfig
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C nsconfig
+echo
 
-# NetScaler::VPNvServer::State
+echo NetScaler::HWInfo
+./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C hwinfo
+echo
+
+echo NetScaler::Interfaces
+./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C interfaces
+echo
+
+echo NetScaler::Perfdata::AAA
+./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
+echo
+
+echo NetScaler::VPNvServer::State
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o vpnvserver
+echo
 
-# NetScaler::LBvServer::State
+echo NetScaler::LBvServer::State
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o lbvserver
+echo
 
-# NetScaler::GSLBvServer::State
+echo NetScaler::GSLBvServer::State
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o gslbvserver
+echo
 
-# NetScaler:::AAAvServer::State
+echo NetScaler:::AAAvServer::State
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o authenticationvserver
+echo
 
-# NetScaler:::CSvServer::State
+echo NetScaler:::CSvServer::State
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o csvserver
+echo
 
-# NetScaler::SSLvServer::State
+#echo NetScaler::SSLvServer::State
 #./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o sslvserver
+#echo
 
-# NetScaler::System::Memory
+echo NetScaler::Server
+./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C server
+echo
+
+echo NetScaler::System::Memory
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n memusagepcnt -w 75 -c 80
+echo
 
-# NetScaler::System::CPU
+echo NetScaler::System::CPU
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n cpuusagepcnt -w 75 -c 80
+echo
 
-# NetScaler::System::CPU::MGMT
+echo NetScaler::System::CPU::MGMT
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
+echo
 
-# NetScaler::System::Disk0
+echo NetScaler::System::Disk0
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n disk0perusage -w 75 -c 80
+echo
 
-# NetScaler::System::Disk1
+echo NetScaler::System::Disk1
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n disk1perusage -w 75 -c 80
+echo
 
-# NetScaler::HA::Status
+echo NetScaler::HA::Status
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C string_not -o hanode -n hacurstatus -w YES -c YES
+echo
 
-# NetScaler::HA::State
+echo NetScaler::HA::State
 ./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C string_not -o hanode -n hacurstate -w UP -c UP
+echo
+
+


### PR DESCRIPTION
- removed whitespace from sub check_server
- added links to contributors in Markdown syntax (GitHub does not recognize the syntax with ‘@user')
- fixed typo (exmaples)
- release v1.2.0
- prepare for v1.2.0, harmonize string quoting
- added new commands to plugin_test.sh
- changed description for service group check
- refactored the documentation
- Merge pull request #19 from bb-Ricardo/master
- enhancing plugin, adding Icinga2 examples
- fixed typo in icinga2 templates file
- Added Icinga2 service examples
- added new commands to Icinga2 templates
- adding cli option -x (urlopts)
- Adding command line option -x / --urlopts to set NITRO URL options for further filtering in debug mode
- added ICA User session example to README
- make use of nagios_die
- I like the name of the function
- merged check_string and check_string_not into one function
- Updated README with latest changes
- updated CHANGELOG for servicegroup command
- added member quorum check to servicegroup command
- now you can define (in percent) how many servicegroup members can go DOWN until you get a WARNING or CRITICAL output
- enhanced performance data output for "perfromancedata"
- unified threshold functions to check_threshold
- added command servicegroup to README
- Update CHANGELOG.md
- Added new command servicegroup
- check the state of a servicegroup and its members
- fixed issue with interfaces perf data output
- performancedata command van now parse arrays
- Now it is possible to get performance data from arrays like Interface.
  - identifier and field name need to be separated by '.'
  - example Interface endpoint:
-  -C performancedata -o Interface -n id.tottxbytes,id.totrxbytes
- added a contributers section to README
- added "performancedata" command to README
- added command performancedata to Changelog
- added new option to gather performancedata
- added option "performancedata" to query stats and counters to forward them to a performance tool of your choice
- add IP adresses to server out in check_netscaler
- Update README.md
- Added new commands to README
- Changelog Update
- Add version information to main script
- added three new commands to check_netscaler.pl
- Added following commands:
  - server -> check status of Load Balancing Servers
  - hwinfo -> just print information about the Netscaler itself
  - interfaces -> check state of all interfaces and add performance data for each interface
- removing trailing white spaces
- fixed templates description
- added icinga2 service templates
- Create icinga2_command.conf
- Added Icinga2 command definition