### PR TITLE
Merge branch development for release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 1.3.0 (2017-XX-XX)
 - added command license to check the status of a local license file (#17)
 - added perl-Time-Piece as new dependency (Time::Piece for license check)
+- added perl-Data-Dumper to the install instructions in the README.md
 - added switch for selecting a different version of the NITRO API (fixes #16)
 - allow the usage of urlopts everywhere (fixes #13)
+- check_threshold and check_string accept arrays (seperated by colon) (fixes #7)
+- renamed checks 'string' and 'string_not' to 'matches' and 'matches_not' ( backwards compatibility given)
 
 ## 1.2.0 (2017-08-12)
 - merged pull request from @bb-Ricardo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-## 1.3.0 (2017-XX-XX)
+## 1.3.0 (2017-08-13)
 - added command license to check the status of a local license file (#17)
 - added perl-Time-Piece as new dependency (Time::Piece for license check)
 - added perl-Data-Dumper to the install instructions in the README.md
 - added switch for selecting a different version of the NITRO API (fixes #16)
 - allow the usage of urlopts everywhere (fixes #13)
 - check_threshold and check_string accept arrays (seperated by colon) (fixes #7)
-- renamed checks 'string' and 'string_not' to 'matches' and 'matches_not' ( backwards compatibility given)
+- renamed checks 'string' and 'string_not' to 'matches' and 'matches_not' (backwards compatibility given)
+- renamed check 'performancedata' to 'perfdata' (backwards compatibility given)
 
 ## 1.2.0 (2017-08-12)
 - merged pull request from @bb-Ricardo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.0 (2017-08-13)
+## v1.3.0 (2017-08-13)
 - added command license to check the status of a local license file (#17)
 - added perl-Time-Piece as new dependency (Time::Piece for license check)
 - added perl-Data-Dumper to the install instructions in the README.md
@@ -6,9 +6,15 @@
 - allow the usage of urlopts everywhere (fixes #13)
 - check_threshold and check_string accept arrays (seperated by colon) (fixes #7)
 - renamed checks 'string' and 'string_not' to 'matches' and 'matches_not' (backwards compatibility given)
-- renamed check 'performancedata' to 'perfdata' (backwards compatibility given)
+- renamed check 'performancedata' to 'perfdata' (backwards compatibility given);
+- backwards compatibility will be removed in a future release, please update your nagios configuration
+- harmonized plugin output for all subcommands
+- refactored sub check_state (cleanup and simplified code)
+  - added support for testing the status of server objects
+  - added a new warning level for DISABLED and PARTIAL-UP objects
+- removed command server (as it might be confusing for users to have two checks with the same function)
 
-## 1.2.0 (2017-08-12)
+## v1.2.0 (2017-08-12)
 - merged pull request from @bb-Ricardo
   - added command server to check status of Load Balancing Servers
   - added command hwinfo to just print information about the Netscaler itself
@@ -18,15 +24,15 @@
   - added Icinga2 config templates
 - updated documentation and plugin_test.sh
 
-## 1.1.1 (2017-06-10)
+## v1.1.1 (2017-06-10)
 - bugfix for servicegroups in 12.0 (#12)
 - new option to connect to an alternate port (for CPX instances)
 
-## 1.1.0 (2017-05-13)
+## v1.1.0 (2017-05-13)
  - new check command for STA services
  - small documentation fixes
 
-## 1.0.0 (2017-02-01)
+## v1.0.0 (2017-02-01)
  - huge rewrite of the Plugin, changed nearly every parameters 
  - upgrading from versions prior to 1.0.0 require to change your monitoring configuration
  - added own nitro implementation and dropped the dependency to Nitro.pm by Citrix
@@ -34,17 +40,17 @@
  - improved check for ssl certificates to only check for a specific certificate
  - fixed a bug in check_state to support services and servicegroups again
 
-## 0.2.0 2017-01-04
+## v0.2.0 2017-01-04
  - patch for Nitro.pm to support ssl connections
  - added check to test the validity and expiry of installed certificates 
 
-## 0.1.2 2016-12-02
+## v0.1.2 2016-12-02
  - added performance data feature 
  - updated sub add_arg and added default values for parameters
  - Bugfix in vserver checks loop by @macampo 
 
-## 0.1.1 2016-11-10
+## v0.1.1 2016-11-10
  - documentation fixes by @Velociraptor85
 
-## 0.1.0 (2015-12-17)
+## v0.1.0 (2015-12-17)
  - First release based on Nitro.pm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.3.0 (2017-XX-XX)
-- added command license to check the status of a local license file
+- added command license to check the status of a local license file (#17)
 - added perl-Time-Piece as new dependency (Time::Piece for license check)
+- added switch for selecting a different version of the NITRO API (fixes #16)
+- allow the usage of urlopts everywhere (fixes #13)
 
 ## 1.2.0 (2017-08-12)
 - merged pull request from @bb-Ricardo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0 (2017-XX-XX)
+- added command license to check the status of a local license file
+- added perl-Time-Piece as new dependency (Time::Piece for license check)
+
 ## 1.2.0 (2017-08-12)
 - merged pull request from @bb-Ricardo
   - added command server to check status of Load Balancing Servers

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Multiple fields need to be seperated by a colon.
 # NetScaler::CPU
 ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n cpuusagepcnt,mgmtcpuusagepcnt -w 75 -c 80
 
-# NetScaler::Disk1
+# NetScaler::Disk
 ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk0perusage,disk1perusage -w 75 -c 80
 
 # NetScaler::HA::Status

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Currently the plugin has the following subcommands:
 **servicegroup**         | check the state of a servicegroup and its members
 **hwinfo**               | just print information about the Netscaler itself
 **interfaces**           | check state of all interfaces and add performance data for each interface
-**performancedata**      | gather performancedata from all sorts of API endpoints
+**perfdata**             | gather performancedata from all sorts of API endpoints
 **debug**                | debug command, print all data for a endpoint
 
 This plugin works with VPX, MPX, SDX and CPX NetScaler Appliances. The api responses may differ by build, appliance type and your installed license.
 
-The plugin supports performance data for the commands state and the above or below threshold checks. Also there is a performancedata command to gather information from your NetScaler.
+The plugin supports performance data for the commands state and the above or below threshold checks. Also there is a perfdata command to gather information from your NetScaler.
 
 Example configurations for Nagios and Icinga 2 can be found in the examples directory of this repository.
 
@@ -47,10 +47,13 @@ yum install perl-LWP-Protocol-https
 
 ## Usage
 ```
-Usage: check_netscaler -H <hostname> [ -P <port> ] [ -u <username> ] [ -p <password> ]
--C <command> [ -o <objecttype> ] [ -n <objectname> ] [ -e <endpoint> ]
-[ -w <warning> ] [ -c <critical> ] [ -v|--verbose ] [ -s|--ssl ]
-[ -t <timeout> ] [ -x <urlopts> ]  [ -a|--api <version> ]
+Usage: check_netscaler
+-H|--hostname=<hostname> -C|--command=<command>
+[ -o|--objecttype=<objecttype> ] [ -n|--objectname=<objectname> ]
+[ -u|--username=<username> ] [ -p|--password=<password> ]
+[ -s|--ssl ] [ -a|--api=<version> ] [ -P|--port=<port> ]
+[ -e|--endpoint=<endpoint> ] [ -w|--warning=<warning> ] [ -c|--critical=<critical> ]
+[ -v|--verbose ] [ -t|--timeout=<timeout> ] [ -x|--urlopts=<urlopts> ]
 
  -?, --usage
    Print usage information
@@ -237,16 +240,16 @@ All fields must be defined via "-n" option and be seperated with a comma.
 
 ```
 # NetScaler::Performancedata on Cache hit/misses
-./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n cachetothits,cachetotmisses
+./check_netscaler.pl -H ${IPADDR} -s -C perfdata -o ns -n cachetothits,cachetotmisses
 
 # NetScaler::Performancedata on tcp connections
-./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o ns -n tcpcurclientconn,tcpcurclientconnestablished,tcpcurserverconn,tcpcurserverconnestablished
+./check_netscaler.pl -H ${IPADDR} -s -C perfdata -o ns -n tcpcurclientconn,tcpcurclientconnestablished,tcpcurserverconn,tcpcurserverconnestablished
 
 # NetScaler::Performancedata on network interfaces
-./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o Interface -n id.totrxbytes
+./check_netscaler.pl -H ${IPADDR} -s -C perfdata -o Interface -n id.totrxbytes
 
 # NetScaler::Current user sessions
-./check_netscaler.pl -H ${IPADDR} -s -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
+./check_netscaler.pl -H ${IPADDR} -s -C perfdata -o aaa -n aaacuricasessions,aaacuricaonlyconn
 
 # find more object names to check out for object type "ns"
 /check_netscaler.pl -H ${IPADDR} -s -C debug -o ns
@@ -255,7 +258,7 @@ All fields must be defined via "-n" option and be seperated with a comma.
 [Global counters](https://docs.citrix.com/en-us/netscaler/12/nitro-api/nitro-rest/nitro-rest-usage-scenarios/view-individual-counter-info.html) can be accessed as follows (NetScaler 12.0 and newer).
 
 ```
-./check_netscaler.pl -H ${IPADDR} -s -C performancedata -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
+./check_netscaler.pl -H ${IPADDR} -s -C perfdata -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
 ```
 
 For more interesting performance data object types see the following API methods.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently the plugin has the following subcommands:
 **above, below**       | check if a value is above/below a threshold (e.g. traffic limits, concurrent connections)
 **sslcert**            | check the lifetime for installed ssl certificates
 **nsconfig**           | check for configuration changes which are not saved to disk
+**license**            | check the expiry date of a local installed license file
 **server**             | check status of Load Balancing Servers
 **staserver**          | check if configured STA (secure ticket authority) servers are available
 **servicegroup**       | check the state of a servicegroup and its members
@@ -28,12 +29,14 @@ Example configurations for Nagios and Icinga 2 can be found in the examples dire
 
 Feedback and feature requests are appreciated. Just create an issue on GitHub or send me a pull request.
 
+If you looking for a plugin to test your NetScaler Gateway vServer and Storefront see also [check_netscaler_gateway](https://github.com/slauger/check_netscaler_gateway).
+
 ## Installation
 
 On a Enterprise Linux machine (CentOS, RHEL) execute the following commands to install all Perl dependencies (Nagios::Plugin, LWP, JSON):
 
 ```
-yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin
+yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin perl-Time-Piece
 ```
 
 If you want to connect to your NetScaler with SSL/HTTPS you should also install the LWP HTTPS package.
@@ -152,6 +155,16 @@ define member quorum (in percent) with warning and critical values
 ```
 # NetScaler::Config
 ./check_netscaler.pl -H ${IPADDR} -s -C nsconfig
+```
+
+### Check the expiry date of a local license file
+
+The license file must be placed in `/nsconfig/license` and the filename must be given as objectname.
+Also the NITRO user needs permissions to access the filesystem directly (NITRO command systemfile).
+
+```
+# NetScaler::License
+./check_netscaler.pl -H ${IPADDR} -s -C license -n FID_4c9a2c7e_14292ea2df2_2a97.lic -w 30 -c 10
 ```
 
 ### Check if STA servers are working

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you looking for a plugin to test your NetScaler Gateway vServer and Storefron
 On a Enterprise Linux machine (CentOS, RHEL) execute the following commands to install all Perl dependencies (Nagios::Plugin, LWP, JSON):
 
 ```
-yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin perl-Time-Piece
+yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin perl-Time-Piece perl-Data-Dumper
 ```
 
 If you want to connect to your NetScaler with SSL/HTTPS you should also install the LWP HTTPS package.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@ Currently the plugin has the following subcommands:
 
 | command                | description |
 ---                      | --- | 
-**state**                | check the current service state of vservers (e.g. lb, vpn, gslb), services and service groups
+**state**                | check the current service state of vservers (e.g. lb, vpn, gslb), services and service groups and servers
 **matches, matches_not** | check if a string exists in the api response or not (e.g. HA or cluster status)
 **above, below**         | check if a value is above/below a threshold (e.g. traffic limits, concurrent connections)
 **sslcert**              | check the lifetime for installed ssl certificates
 **nsconfig**             | check for configuration changes which are not saved to disk
 **license**              | check the expiry date of a local installed license file
-**server**               | check status of Load Balancing Servers
 **staserver**            | check if configured STA (secure ticket authority) servers are available
 **servicegroup**         | check the state of a servicegroup and its members
 **hwinfo**               | just print information about the Netscaler itself
@@ -152,14 +151,14 @@ Define member quorum (in percent) with warning and critical values.
 ./check_netscaler.pl -H ${IPADDR} -s -C servicegroup -n sg_webservers -w 75 -c 50
 ```
 
-### Check if Load Balancing servers are enabled
+### Check status of server objects
 
 ```
-# NetScaler::Server
-./check_netscaler.pl -H ${IPADDR} -s -C server
+# NetScaler::Servers
+./check_netscaler.pl -H ${IPADDR} -s -C state -o server
 
-# NetScaler::Server
-./check_netscaler.pl -H ${IPADDR} -s -C server -n web01.example.com
+# NetScaler::Servers::web01.example.com
+./check_netscaler.pl -H ${IPADDR} -s -C state -o server -n web01.example.com
 ```
 
 ### Check for thresholds or matching strings

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Usage: check_netscaler
 
 ### Check status and quorum of a service group
 
-define member quorum (in percent) with warning and critical values
+Define member quorum (in percent) with warning and critical values.
 
 ```
 # NetScaler::Servicegroup::Webservers
@@ -292,8 +292,10 @@ define command {
 
 ```
 [netscaler]
+hostname=netscaler01
 username=nagios
 password=password
+ssl=true
 ```
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -111,28 +111,20 @@ define member quorum (in percent) with warning and critical values
 ./check_netscaler.pl -H ${IPADDR} -s -C server -n web01.example.com
 ```
 
-### Check system health
+### Check for thresholds or matching strings
+
+Multiple fields need to be seperated by a colon.
 
 ```
 # NetScaler::Memory
 ./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n memusagepcnt -w 75 -c 80
 
 # NetScaler::CPU
-./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n cpuusagepcnt -w 75 -c 80
-
-# NetScaler::CPUMGMT
-./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
-
-# NetScaler::Disk0
-./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk0perusage -w 75 -c 80
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n cpuusagepcnt,mgmtcpuusagepcnt -w 75 -c 80
 
 # NetScaler::Disk1
-./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk1perusage -w 75 -c 80
-```
+./check_netscaler.pl -H ${IPADDR} -s -C above -o system -n disk0perusage,disk1perusage -w 75 -c 80
 
-### Check high availability status
-
-```
 # NetScaler::HA::Status
 ./check_netscaler.pl -H ${IPADDR} -s -C matches_not -o hanode -n hacurstatus -w YES -c YES
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ All fields must be defined via "-n" option and be seperated with a comma.
 /check_netscaler.pl -H ${IPADDR} -s -C debug -o ns
 ```
 
+[Global counters](https://docs.citrix.com/en-us/netscaler/12/nitro-api/nitro-rest/nitro-rest-usage-scenarios/view-individual-counter-info.html) can be accessed as follows (NetScaler 12.0 and newer).
+
+```
+./check_netscaler.pl -H ${IPADDR} -s -C performancedata -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
+```
+
 For more interesting performance data object types see the following API methods.
 
 - ns

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you looking for a plugin to test your NetScaler Gateway vServer and Storefron
 
 ## Installation
 
-On a Enterprise Linux machine (CentOS, RHEL) execute the following commands to install all Perl dependencies (Nagios::Plugin, LWP, JSON):
+On a Enterprise Linux machine (CentOS, RHEL) execute the following commands to install all Perl dependencies (Nagios::Plugin, LWP, JSON, Time-Piece, Data-Dumper):
 
 ```
 yum install perl-libwww-perl perl-JSON perl-Nagios-Plugin perl-Time-Piece perl-Data-Dumper

--- a/README.md
+++ b/README.md
@@ -45,6 +45,54 @@ If you want to connect to your NetScaler with SSL/HTTPS you should also install 
 yum install perl-LWP-Protocol-https
 ```
 
+## Usage
+```
+Usage: check_netscaler -H <hostname> [ -P <port> ] [ -u <username> ] [ -p <password> ]
+-C <command> [ -o <objecttype> ] [ -n <objectname> ] [ -e <endpoint> ]
+[ -w <warning> ] [ -c <critical> ] [ -v|--verbose ] [ -s|--ssl ]
+[ -t <timeout> ] [ -x <urlopts> ]  [ -a|--api <version> ]
+
+ -?, --usage
+   Print usage information
+ -h, --help
+   Print detailed help screen
+ -V, --version
+   Print version information
+ --extra-opts=[section][@file]
+   Read options from an ini file. See http://nagiosplugins.org/extra-opts
+   for usage and examples.
+ -H, --hostname=STRING
+   Hostname of the NetScaler appliance to connect to
+ -u, --username=STRING
+   Username to log into box as (default: nsroot)
+ -p, --password=STRING
+   Password for login username (default: nsroot)
+ -s, --ssl
+   Establish connection to NetScaler using SSL
+ -P, --port=INTEGER
+   Establish connection to a alternate TCP Port
+ -C, --command=STRING
+   Check to be executed on the appliance
+ -o, --objecttype=STRING
+   Objecttype (target) to for the check command
+ -n, --objectname=STRING
+   Filter request to a specific objectname
+ -e, --endpoint=STRING
+   Override option for the API endpoint (stat or config)
+ -w, --warning=STRING
+   Value for warning
+ -c, --critical=STRING
+   Value for critical
+ -x, --urlopts=STRING
+   add additional url options
+ -a, --api=STRING
+   version of the NITRO API to use (default: v1)
+ -t, --timeout=INTEGER
+   Seconds before plugin times out (default: 15)
+ -v, --verbose
+   Show details for command-line debugging (can repeat up to 3 times)
+```
+
 ## Usage Examples
 
 ### Check status of vServers

--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ A Nagios Plugin written for the Citrix NetScaler Application Delivery Controller
 Currently the plugin has the following subcommands:
 
 
-| command | description |
----       | --- | 
-**state**              | check the current service state of vservers (e.g. lb, vpn, gslb), services and service groups
-**string, string_not** | check if a string exists in the api response or not (e.g. HA or cluster status)
-**above, below**       | check if a value is above/below a threshold (e.g. traffic limits, concurrent connections)
-**sslcert**            | check the lifetime for installed ssl certificates
-**nsconfig**           | check for configuration changes which are not saved to disk
-**license**            | check the expiry date of a local installed license file
-**server**             | check status of Load Balancing Servers
-**staserver**          | check if configured STA (secure ticket authority) servers are available
-**servicegroup**       | check the state of a servicegroup and its members
-**hwinfo**             | just print information about the Netscaler itself
-**interfaces**         | check state of all interfaces and add performance data for each interface
-**performancedata**    | gather performancedata from all sorts of API endpoints
-**debug**              | debug command, print all data for a endpoint
+| command                | description |
+---                      | --- | 
+**state**                | check the current service state of vservers (e.g. lb, vpn, gslb), services and service groups
+**matches, matches_not** | check if a string exists in the api response or not (e.g. HA or cluster status)
+**above, below**         | check if a value is above/below a threshold (e.g. traffic limits, concurrent connections)
+**sslcert**              | check the lifetime for installed ssl certificates
+**nsconfig**             | check for configuration changes which are not saved to disk
+**license**              | check the expiry date of a local installed license file
+**server**               | check status of Load Balancing Servers
+**staserver**            | check if configured STA (secure ticket authority) servers are available
+**servicegroup**         | check the state of a servicegroup and its members
+**hwinfo**               | just print information about the Netscaler itself
+**interfaces**           | check state of all interfaces and add performance data for each interface
+**performancedata**      | gather performancedata from all sorts of API endpoints
+**debug**                | debug command, print all data for a endpoint
 
 This plugin works with VPX, MPX, SDX and CPX NetScaler Appliances. The api responses may differ by build, appliance type and your installed license.
 
@@ -134,10 +134,10 @@ define member quorum (in percent) with warning and critical values
 
 ```
 # NetScaler::HA::Status
-./check_netscaler.pl -H ${IPADDR} -s -C string_not -o hanode -n hacurstatus -w YES -c YES
+./check_netscaler.pl -H ${IPADDR} -s -C matches_not -o hanode -n hacurstatus -w YES -c YES
 
 # NetScaler::HA::State
-./check_netscaler.pl -H ${IPADDR} -s -C string_not -o hanode -n hacurstate -w UP -c UP
+./check_netscaler.pl -H ${IPADDR} -s -C matches_not -o hanode -n hacurstate -w UP -c UP
 ```
 
 ### Check expiration of installed ssl certificates

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Multiple fields need to be seperated by a colon.
 The license file must be placed in `/nsconfig/license` and the filename must be given as objectname.
 Also the NITRO user needs permissions to access the filesystem directly (NITRO command systemfile).
 
-Multiple fasta files can be passed, separated with a colon.
+Multiple license files can be passed, separated with a colon.
 
 ```
 # NetScaler::License

--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ Multiple fields need to be seperated by a colon.
 The license file must be placed in `/nsconfig/license` and the filename must be given as objectname.
 Also the NITRO user needs permissions to access the filesystem directly (NITRO command systemfile).
 
+Multiple fasta files can be passed, separated with a colon.
+
 ```
 # NetScaler::License
-./check_netscaler.pl -H ${IPADDR} -s -C license -n FID_4c9a2c7e_14292ea2df2_2a97.lic -w 30 -c 10
+./check_netscaler.pl -H ${IPADDR} -s -C license -n FID_4c9a2c7e_14292ea2df2_2a97.lic,FID_2b9a2c7e_14212ef2d27_4b87.lic -w 30 -c 10
 ```
 
 ### Check if STA servers are working
@@ -258,7 +260,7 @@ All fields must be defined via "-n" option and be seperated with a comma.
 [Global counters](https://docs.citrix.com/en-us/netscaler/12/nitro-api/nitro-rest/nitro-rest-usage-scenarios/view-individual-counter-info.html) can be accessed as follows (NetScaler 12.0 and newer).
 
 ```
-./check_netscaler.pl -H ${IPADDR} -s -C perfdata -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
+./check_netscaler.pl -H ${IPADDR} -s -C perfdata -o nsglobalcntr -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
 ```
 
 For more interesting performance data object types see the following API methods.

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -563,9 +563,9 @@ sub check_server
 	# check if any server is in disabled state
 	foreach $response (@{$response}) {
 		if ($response->{'state'} ne 'ENABLED') {
-			$plugin->add_message(WARNING, $response->{'name'} . '('. $response->{'ipaddress'} .') ' . $response->{'state'} . ' ;');
+			$plugin->add_message(WARNING, $response->{'name'} . '('. $response->{'ipaddress'} .') ' . $response->{'state'} . ';');
 		} else {
-			$plugin->add_message(OK, $response->{'name'} . '('. $response->{'ipaddress'} .') ' . $response->{'state'} . ' ;');
+			$plugin->add_message(OK, $response->{'name'} . '('. $response->{'ipaddress'} .') ' . $response->{'state'} . ';');
 			$critical = 0;
 		}
 	}

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -161,11 +161,11 @@ if ($plugin->opts->command eq 'state') {
 # be backwards compatible; also accept command 'string'
 } elsif ($plugin->opts->command eq 'matches' || $plugin->opts->command eq 'string') {
 	# check if a response does contains a specific string
-	check_string($plugin, 'matches');
+	check_keyword($plugin, 'matches');
 # be backwards compatible; also accept command 'string_not'
 } elsif ($plugin->opts->command eq 'matches_not' || $plugin->opts->command eq 'string_not') {
 	# check if a response does not contains a specific string
-	check_string($plugin, 'matches not');
+	check_keyword($plugin, 'matches not');
 } elsif ($plugin->opts->command eq 'sslcert') {
 	# check for the lifetime of installed certificates
 	check_sslcert($plugin);
@@ -403,7 +403,7 @@ sub check_state
 	}
 }
 
-sub check_string
+sub check_keyword
 {
 	my $plugin = shift;
 	my $type_of_string_comparison = shift;
@@ -435,17 +435,17 @@ sub check_string
 
 	foreach ( split(',', $plugin->opts->objectname) ) {
 		if (($type_of_string_comparison eq 'matches' && $response->{$_} eq $plugin->opts->critical) || ($type_of_string_comparison eq 'matches not' && $response->{$_} ne $plugin->opts->critical)) {
-			$plugin->add_message(CRITICAL, $plugin->opts->objecttype . '::' . $_ . ' ' . $type_of_string_comparison . ' keyword (current: ' . $response->{$_} . ', critical: ' . $plugin->opts->critical . ');');
+			$plugin->add_message(CRITICAL, $plugin->opts->objecttype . '.' . $_ . ': "' . $response->{$_} . '" ' . $type_of_string_comparison . ' keyword "' . $plugin->opts->critical . '";');
 		} elsif (($type_of_string_comparison eq 'matches' && $response->{$_} eq $plugin->opts->warning) || ($type_of_string_comparison eq 'matches not' && $response->{$_} ne $plugin->opts->warning)) {
-			$plugin->add_message(WARNING, $plugin->opts->objecttype . '::' . $_ . ' ' . $type_of_string_comparison . ' keyword (current: ' . $response->{$_} . ', warning: ' . $plugin->opts->warning . ');');
+			$plugin->add_message(WARNING, $plugin->opts->objecttype . '.' . $_ . ': "' . $response->{$_} . '" ' . $type_of_string_comparison . ' keyword "' . $plugin->opts->warning . '";');
 		} else {
-			$plugin->add_message(OK, $plugin->opts->objecttype . '::' . $_ . ' OK ('.$response->{$_}.');');
+			$plugin->add_message(OK, $plugin->opts->objecttype . '.' . $_ . ': '.$response->{$_}.';');
 		}
 	}
 
 	my ($code, $message) = $plugin->check_messages;
 
-	$plugin->nagios_exit($code, $plugin->opts->command . ': ' . $message);
+	$plugin->nagios_exit($code, 'keyword ' . $type_of_string_comparison . ': ' . $message);
 }
 
 sub check_threshold
@@ -480,7 +480,7 @@ sub check_threshold
 
 	foreach ( split(',', $plugin->opts->objectname) ) {
 		$plugin->add_perfdata(
-			label    => $plugin->opts->objecttype . '::' . $_,
+			label    => $plugin->opts->objecttype . '.' . $_,
 			value    => $response->{$_},
 			min      => undef,
 			max      => undef,
@@ -489,16 +489,16 @@ sub check_threshold
 		);
 
 		if (($direction eq 'above' && $response->{$_} >= $plugin->opts->critical) || ($direction eq 'below' && $response->{$_} <= $plugin->opts->critical)) {
-			$plugin->add_message(CRITICAL, $plugin->opts->objecttype . '::' . $_ . ' is ' . $direction . ' threshold (current: ' . $response->{$_} . ', critical: ' . $plugin->opts->critical . ');');
+			$plugin->add_message(CRITICAL, $plugin->opts->objecttype . '.' . $_ . ' is ' . $direction . ' threshold (current: ' . $response->{$_} . ', critical: ' . $plugin->opts->critical . ');');
 		} elsif (($direction eq 'above' && $response->{$_} >= $plugin->opts->warning) || ($direction eq 'below' && $response->{$_} <= $plugin->opts->warning)) {
-			$plugin->add_message(WARNING, $plugin->opts->objecttype . '::' . $_ . ' is ' . $direction . ' threshold (current: ' . $response->{$_} . ', warning: ' . $plugin->opts->warning . ');');
+			$plugin->add_message(WARNING, $plugin->opts->objecttype . '.' . $_ . ' is ' . $direction . ' threshold (current: ' . $response->{$_} . ', warning: ' . $plugin->opts->warning . ');');
 		} else {
-			$plugin->add_message(OK, $_ . '::' . $_ . '   ('.$response->{$_}.')');
+			$plugin->add_message(OK, $_ . '.' . $_ . ': '.$response->{$_} . ';');
 		}
 	}
 
 	my ($code, $message) = $plugin->check_messages;
-	$plugin->nagios_exit($code, $plugin->opts->command . ': ' . $message);
+	$plugin->nagios_exit($code, 'threshold ' . $plugin->opts->command . ': ' . $message);
 }
 
 sub check_sslcert

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -6,7 +6,7 @@
 #
 # https://github.com/slauger/check_netscaler
 #
-# Version: 1.3.0 (2017-08-13)
+# Version: v1.3.0 (2017-08-13)
 #
 # Copyright 2015-2017 Simon Lauger
 #
@@ -37,7 +37,7 @@ use Time::Piece;
 my $plugin = Nagios::Plugin->new(
 	plugin		=> 'check_netscaler',
 	shortname	=> 'NetScaler',
-	version		=> '1.3.0',
+	version		=> 'v1.3.0',
 	url		=> 'https://github.com/slauger/check_netscaler',
 	blurb		=> 'Nagios Plugin for Citrix NetScaler Appliance (VPX/MPX/SDX/CPX)',
 	usage		=> 'Usage: %s

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -130,6 +130,13 @@ my @args = (
 		desc => 'add additional url options',
 		required => 0,
 	},
+	{
+		spec => 'api|a=s',
+		usage => '-a, --api=STRING',
+		desc => 'version of the NITRO API to use',
+		required => 0,
+		default => 'v1',
+	}
 );
 
 foreach my $arg (@args) {
@@ -252,7 +259,7 @@ sub nitro_client {
 		$port = '';
 	}
 
-	my $url = $protocol . $plugin->opts->hostname . $port . '/nitro/v1/' . $params->{'endpoint'} . '/' . $params->{'objecttype'};
+	my $url = $protocol . $plugin->opts->hostname . $port . '/nitro/' . $plugin->opts->api . '/' . $params->{'endpoint'} . '/' . $params->{'objecttype'};
 
 	if ($params->{'objectname'} && $params->{'objectname'} ne '') {
 		$url  = $url . '/' . uri_escape(uri_escape($params->{'objectname'}));

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -40,9 +40,8 @@ my $plugin = Nagios::Plugin->new(
 	version		=> '1.3.0',
 	url		=> 'https://github.com/slauger/check_netscaler',
 	blurb		=> 'Nagios Plugin for Citrix NetScaler Appliance (VPX/MPX/SDX/CPX)',
-	usage		=> 'Usage: %s -H <hostname> [ -u <username> ] [ -p <password> ]
--C <command> [ -o <objecttype> ] [ -n <objectname> ] [ -e <endpoint> ]
-[ -w <warning> ] [ -c <critical> ] [ -v|--verbose ] [ -s|--ssl ] [ -t <timeout> ]',
+	usage		=> 'Usage: %s -H <hostname> [ -P <port> ] [ -u <username> ] [ -p <password> ] -C <command> [ -o <objecttype> ] [ -n <objectname> ] [ -e <endpoint> ]
+[ -w <warning> ] [ -c <critical> ] [ -v|--verbose ] [ -s|--ssl ] [ -t <timeout> ] [ -x <urlopts> ]  [ -a|--api <version> ]',
 	license		=> 'http://www.apache.org/licenses/LICENSE-2.0',
  	extra		=> '
 This is a Nagios monitoring plugin for the Citrix NetScaler. The plugin works with
@@ -133,7 +132,7 @@ my @args = (
 	{
 		spec => 'api|a=s',
 		usage => '-a, --api=STRING',
-		desc => 'version of the NITRO API to use',
+		desc => 'version of the NITRO API to use (default: v1)',
 		required => 0,
 		default => 'v1',
 	}

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -127,7 +127,7 @@ my @args = (
 	{
 		spec => 'urlopts|x=s',
 		usage => '-x, --urlopts=STRING',
-		desc => 'DEBUG ONLY: add additional url options',
+		desc => 'add additional url options',
 		required => 0,
 	},
 );
@@ -325,7 +325,7 @@ sub check_state
 
 	$params{'objecttype'} = $plugin->opts->objecttype;
 	$params{'objectname'} = $plugin->opts->objectname;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$plugin->opts->objecttype};
@@ -414,7 +414,7 @@ sub check_string
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'stat';
 	$params{'objecttype'} = $plugin->opts->objecttype;
 	$params{'objectname'} = undef;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$plugin->opts->objecttype};
@@ -453,7 +453,7 @@ sub check_threshold
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'stat';
 	$params{'objecttype'} = $plugin->opts->objecttype;
 	$params{'objectname'} = undef;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$plugin->opts->objecttype};
@@ -488,7 +488,7 @@ sub check_sslcert
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'config';
 	$params{'objecttype'} = $plugin->opts->objecttype || 'sslcertkey';
 	$params{'objectname'} = $plugin->opts->objectname;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
@@ -517,7 +517,7 @@ sub check_staserver
 	my %params;
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'config';
 	$params{'objectname'} = $plugin->opts->objectname || '';
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	if ($params{'objectname'} eq '') {
 		$params{'objecttype'} = $plugin->opts->objecttype || 'vpnglobal_staserver_binding';
@@ -555,7 +555,7 @@ sub check_server
 	my %params;
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'config';
 	$params{'objectname'} = $plugin->opts->objectname || '';
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 	$params{'objecttype'} = 'server';
 
 	my $response = nitro_client($plugin, \%params);
@@ -589,7 +589,7 @@ sub check_nsconfig
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'config';
 	$params{'objecttype'} = $plugin->opts->objecttype || 'nsconfig';
 	$params{'objectname'} = undef;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
@@ -609,7 +609,7 @@ sub get_hardware_info
 	$params{'endpoint'}   = 'config';
 	$params{'objecttype'} = 'nshardware';
 	$params{'objectname'} = undef;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 	$response = $response->{$params{'objecttype'}};
@@ -638,7 +638,7 @@ sub get_performancedata
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'stat';
 	$params{'objecttype'} = $plugin->opts->objecttype;
 	$params{'objectname'} = undef;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	if (!defined $plugin->opts->objectname) {
 		$plugin->nagios_die('performancedata: command requires parameter for objectname');
@@ -708,7 +708,7 @@ sub check_interfaces
 	$params{'endpoint'}   = 'config';
 	$params{'objecttype'} = 'interface';
 	$params{'objectname'} = undef;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	my $response = nitro_client($plugin, \%params);
 
@@ -774,7 +774,7 @@ sub check_servicegroup
 	$params{'endpoint'}   = 'config';
 	$params{'objecttype'} = 'servicegroup';
 	$params{'objectname'} = $plugin->opts->objectname;
-	$params{'options'}    = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	if (not defined ($plugin->opts->objectname)) {
 		$plugin->nagios_die('servicegroup: no object name "-n" set');
@@ -873,7 +873,7 @@ sub check_license
 	my %params;
 	$params{'endpoint'}   = $plugin->opts->endpoint || 'config';
 	$params{'objecttype'} = 'systemfile';
-	$params{'objectname'} = undef;
+	$params{'options'}    = $plugin->opts->urlopts;
 
 	if (!defined $plugin->opts->warning || !$plugin->opts->critical) {
 		$plugin->nagios_die('command requires parameter for warning and critical');

--- a/examples/icinga2_service_templates.conf
+++ b/examples/icinga2_service_templates.conf
@@ -79,7 +79,7 @@ template Service "netscaler_ha_status_template" {
 
 	check_command = "netscaler"
 
-	vars.netscaler_command = "string_not"
+	vars.netscaler_command = "matches_not"
 	vars.netscaler_objecttype = "hanode"
 	vars.netscaler_objectname = "hacurstatus"
 
@@ -92,7 +92,7 @@ template Service "netscaler_ha_state_template" {
 
 	check_command = "netscaler"
 
-	vars.netscaler_command = "string_not"
+	vars.netscaler_command = "matches_not"
 	vars.netscaler_objecttype = "hanode"
 	vars.netscaler_objectname = "hacurstate"
 

--- a/examples/icinga2_service_templates.conf
+++ b/examples/icinga2_service_templates.conf
@@ -142,7 +142,8 @@ template Service "netscaler_server_template" {
 
 	check_command = "netscaler"
 
-	vars.netscaler_command = "server"
+	vars.netscaler_command = "state"
+	vars.netscaler_objecttype = "server"
 }
 
 template Service "netscaler_lbvserver_template" {

--- a/examples/nagios_command.cfg
+++ b/examples/nagios_command.cfg
@@ -22,16 +22,16 @@ define command {
   command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C below -o '$ARG1$' -n '$ARG2$' -w '$ARG3$' -c '$ARG4$'
 }
 
-# check_netscaler_string!objecttype!objectname!warning!critical
+# check_netscaler_matches!objecttype!objectname!warning!critical
 define command {
-  command_name check_netscaler_string
-  command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C string -o '$ARG1$' -n '$ARG2$' -w '$ARG3$' -c '$ARG4$'
+  command_name check_netscaler_matches
+  command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C matches -o '$ARG1$' -n '$ARG2$' -w '$ARG3$' -c '$ARG4$'
 }
 
-# check_netscaler_string_not!objecttype!objectname!warning!critical
+# check_netscaler_matches_not!objecttype!objectname!warning!critical
 define command {
-  command_name check_netscaler_string_not
-  command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C string_now -o '$ARG1$' -n '$ARG2$' -w '$ARG3$' -c '$ARG4$'
+  command_name check_netscaler_matches_not
+  command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C matches_not -o '$ARG1$' -n '$ARG2$' -w '$ARG3$' -c '$ARG4$'
 }
 
 # check_netscaler_sslcert!warning!critical
@@ -43,7 +43,7 @@ define command {
 # check_netscaler_sslcert_single!objectname!warning!critical
 define command {
   command_name check_netscaler_sslcert_single
-  command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C string -n '$ARG1$' -w '$ARG2$' -c '$ARG3$'
+  command_line /opt/check_netscaler/check_netscaler.pl -H $HOSTADDRESS$ --extra-opts=netscaler@$USER11$/plugins.ini -C matches -n '$ARG1$' -w '$ARG2$' -c '$ARG3$'
 }
 
 # check_netscaler_nsconfig

--- a/examples/plugin_test.sh
+++ b/examples/plugin_test.sh
@@ -66,7 +66,7 @@ echo
 #echo
 
 echo NetScaler::Server
-./check_netscaler.pl --extra-opts=${section}@${1} -C server
+./check_netscaler.pl --extra-opts=${section}@${1} -C state -o server
 echo
 
 echo NetScaler::STA

--- a/examples/plugin_test.sh
+++ b/examples/plugin_test.sh
@@ -3,7 +3,7 @@
 if [ ! -f "${1}" ]; then
   echo "ERROR: config file not found or not readable"
   echo ""
-  echo "Syntax: $0 <config.ini>"
+  echo "Syntax: $0 <config.ini> [<section>]"
   echo ""
   echo "Configuration example:"
   echo ""
@@ -69,24 +69,20 @@ echo NetScaler::Server
 ./check_netscaler.pl --extra-opts=${section}@${1} -C server
 echo
 
+echo NetScaler::STA
+./check_netscaler.pl --extra-opts=${section}@${1} -C staserver
+echo
+
 echo NetScaler::System::Memory
 ./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n memusagepcnt -w 75 -c 80
 echo
 
 echo NetScaler::System::CPU
-./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n cpuusagepcnt -w 75 -c 80
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n cpuusagepcnt,mgmtcpuusagepcnt -w 75 -c 80
 echo
 
-echo NetScaler::System::CPU::MGMT
-./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
-echo
-
-echo NetScaler::System::Disk0
-./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n disk0perusage -w 75 -c 80
-echo
-
-echo NetScaler::System::Disk1
-./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n disk1perusage -w 75 -c 80
+echo NetScaler::System::Disk
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n disk0perusage,disk1perusage -w 75 -c 80
 echo
 
 echo NetScaler::HA::Status
@@ -97,4 +93,6 @@ echo NetScaler::HA::State
 ./check_netscaler.pl --extra-opts=${section}@${1} -C matches_not -o hanode -n hacurstate -w UP -c UP
 echo
 
-
+echo NetScaler::Perfdata::HTTP
+./check_netscaler.pl --extra-opts=${section}@${1} -C perfdata -o nsglobalcntr -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
+echo

--- a/examples/plugin_test.sh
+++ b/examples/plugin_test.sh
@@ -1,119 +1,100 @@
 #!/bin/bash
 
-# default ipaddr 
-if [ "${1}" = "" ];
-then
-	echo "Syntax: $0 <hostname> [<username>] [<password>] [(bool) ssl]"
-	exit 1
-else
-	IPADDR="${1}"
+if [ ! -f "${1}" ]; then
+  echo "ERROR: config file not found or not readable"
+  echo ""
+  echo "Syntax: $0 <config.ini>"
+  echo ""
+  echo "Configuration example:"
+  echo ""
+  echo "  [netscaler]"
+  echo "  username=nsroot"
+  echo "  password=nsroot"
+  echo "  hostname=netscaler01.example.local"
+  echo "  ssl=true"
+  exit 1
 fi
 
-# default username
-if [ "${2}" = "" ];
-then
-	USERNAME="nsroot"
+if [ "${2}" != "" ]; then
+  section="${2}"
 else
-	USERNAME=${2}
-fi
-
-# default password
-if [ "${3}" = "" ];
-then
-        PASSWORD="nsroot"
-else
-        PASSWORD=${3}
-fi
-
-# enable ssl
-if [ "${4}" == "true" ];
-then
-	SSL="-s"
-else
-	SSL=""
-fi
-
-if [ "${5}" = "" ];
-then
-	PORT=""
-else
-	PORT="-P ${5}"
+  section="netscaler"
 fi
 
 echo NetScaler::SSLCerts
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C sslcert -w 30 -c 10
+./check_netscaler.pl --extra-opts=${section}@${1} -C sslcert -w 30 -c 10
 echo
 
 echo NetScaler::NSConfig
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C nsconfig
+./check_netscaler.pl --extra-opts=${section}@${1} -C nsconfig
 echo
 
 echo NetScaler::HWInfo
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C hwinfo
+./check_netscaler.pl --extra-opts=${section}@${1} -C hwinfo
 echo
 
 echo NetScaler::Interfaces
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C interfaces
+./check_netscaler.pl --extra-opts=${section}@${1} -C interfaces
 echo
 
 echo NetScaler::Perfdata::AAA
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
+./check_netscaler.pl --extra-opts=${section}@${1} -C performancedata -o aaa -n aaacuricasessions,aaacuricaonlyconn
 echo
 
 echo NetScaler::VPNvServer::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o vpnvserver
+./check_netscaler.pl --extra-opts=${section}@${1} -C state -o vpnvserver
 echo
 
 echo NetScaler::LBvServer::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o lbvserver
+./check_netscaler.pl --extra-opts=${section}@${1} -C state -o lbvserver
 echo
 
 echo NetScaler::GSLBvServer::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o gslbvserver
+./check_netscaler.pl --extra-opts=${section}@${1} -C state -o gslbvserver
 echo
 
 echo NetScaler:::AAAvServer::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o authenticationvserver
+./check_netscaler.pl --extra-opts=${section}@${1} -C state -o authenticationvserver
 echo
 
 echo NetScaler:::CSvServer::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o csvserver
+./check_netscaler.pl --extra-opts=${section}@${1} -C state -o csvserver
 echo
 
 #echo NetScaler::SSLvServer::State
-#./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C state -o sslvserver
+#./check_netscaler.pl --extra-opts=${section}@${1} -C state -o sslvserver
 #echo
 
 echo NetScaler::Server
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C server
+./check_netscaler.pl --extra-opts=${section}@${1} -C server
 echo
 
 echo NetScaler::System::Memory
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n memusagepcnt -w 75 -c 80
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n memusagepcnt -w 75 -c 80
 echo
 
 echo NetScaler::System::CPU
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n cpuusagepcnt -w 75 -c 80
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n cpuusagepcnt -w 75 -c 80
 echo
 
 echo NetScaler::System::CPU::MGMT
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n mgmtcpuusagepcnt -w 75 -c 80
 echo
 
 echo NetScaler::System::Disk0
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n disk0perusage -w 75 -c 80
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n disk0perusage -w 75 -c 80
 echo
 
 echo NetScaler::System::Disk1
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C above -o system -n disk1perusage -w 75 -c 80
+./check_netscaler.pl --extra-opts=${section}@${1} -C above -o system -n disk1perusage -w 75 -c 80
 echo
 
 echo NetScaler::HA::Status
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C matches_not -o hanode -n hacurstatus -w YES -c YES
+./check_netscaler.pl --extra-opts=${section}@${1} -C matches_not -o hanode -n hacurstatus -w YES -c YES
 echo
 
 echo NetScaler::HA::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C matches_not -o hanode -n hacurstate -w UP -c UP
+./check_netscaler.pl --extra-opts=${section}@${1} -C matches_not -o hanode -n hacurstate -w UP -c UP
 echo
 
 

--- a/examples/plugin_test.sh
+++ b/examples/plugin_test.sh
@@ -109,11 +109,11 @@ echo NetScaler::System::Disk1
 echo
 
 echo NetScaler::HA::Status
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C string_not -o hanode -n hacurstatus -w YES -c YES
+./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C matches_not -o hanode -n hacurstatus -w YES -c YES
 echo
 
 echo NetScaler::HA::State
-./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C string_not -o hanode -n hacurstate -w UP -c UP
+./check_netscaler.pl -H ${IPADDR} ${PORT} ${SSL} -u ${USERNAME} -p ${PASSWORD} -C matches_not -o hanode -n hacurstate -w UP -c UP
 echo
 
 


### PR DESCRIPTION
-  updated CHANGELOG.md for release v1.3.0
-  removed command server from the plugin (replaced by state in v1.3.0)
-  refactoring of check_state
-  cleanup and simplified code (counter etc.)
-  added support for testing servers (makes check_server obsolet)
-  added warning level for DISABLED and PARTIAL-UP
-  harmonize output of threshold and keyword check
-  harmonize plugin output for all commands
-  fixed documentation bug (nsglobalcntr)
-  check_license does now support testing of multiple license files in a single check
-  plugin_test.sh does now use --extra-opts to be more flexible
-  smalld documentation fixes
-  plugin_test.sh now uses --extra-opts
-  added Time-Piece and Data-Dumper in the installation instructions
-  renamed check performancedata to perfdata (backwards compatible); small documentation changes
-  added usage examples to README.md
-  Disk1 -> Disk
-  updated examples for threshold and string checks (#7); updated CHANGELOG.md with recent changes
-  renamed checks 'string' and 'string_not' to 'matches' and 'matches_not' (with backwards compatibility)
-  accept multiple values for threshold checks (#7)
-  added perl-Data-Dumper to the dependencies
-  updated CHANGELOG.md with the recent changes
-  added switch --api to select a different version of the NITRO API (#16)
-  added example for requesting performance data from global counters (#13)
-  allow usage of urlopts everywhere (also fixes #13)
-  added sub check_license to check the expiry date of a license file (#17)
-  removed whitespace from sub check_server