### PR TITLE
add NTP command #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v1.4.0 (2017-08-XX)
+- added command ntp to check NTP status (#18)
 ## v1.3.0 (2017-08-13)
 - added command license to check the status of a local license file (#17)
 - added perl-Time-Piece as new dependency (Time::Piece for license check)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently the plugin has the following subcommands:
 **hwinfo**               | just print information about the Netscaler itself
 **interfaces**           | check state of all interfaces and add performance data for each interface
 **perfdata**             | gather performancedata from all sorts of API endpoints
+**ntp**                  | check the ntp synchronization status
 **debug**                | debug command, print all data for a endpoint
 
 This plugin works with VPX, MPX, SDX and CPX NetScaler Appliances. The api responses may differ by build, appliance type and your installed license.
@@ -269,6 +270,29 @@ For more interesting performance data object types see the following API methods
 - protocolhttp
 - protocolip
 - protocoltcp
+
+### check NTP status
+This is pretty much a reimplementation of [check_ntp_peer](https://github.com/monitoring-plugins/monitoring-plugins/blob/master/plugins/check_ntp_peer.c). Output format and performance data should match to 99%.
+Also the behaviour of the warning and critical threshold checking got matched to check_ntp_peer.
+To avoid adding a couple of extra command line options the thresholds can be set with following options. Format: "option=value". They have to be comma separated.
+* o -> offset
+* s -> stratum
+* j -> jitter
+* t -> truechimers
+
+```
+# check NTP status
+./check_netscaler.pl -H ${IPADDR} -s -C ntp -w o=0.03,j=100,s=1,t=3 -c o=0.05,j=200,s=2,t=2
+```
+This means:
+* offset WARNING if peer offset is >= 30 ms or <= - 30 ms
+* jitter WARNING if jitter is >= 100 ms
+* stratum WARNING if peer stratum > 1
+* truechimers WARNING if number of truechimers (possible sync sources) is <= 3
+* offset CRITICAL if peer offset is >= 50 ms or <= - 50 ms
+* jitter CRITICAL if jitter is >= 200 ms
+* stratum CRITICAL if peer stratum > 2
+* truechimers CRITICAL if number of truechimers (possible sync sources) is <= 2
 
 ## Debug command
 

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -881,14 +881,19 @@ sub check_license
 				@stripped = split(' ', $_);
 
 				# date format in license file, e.g. 18-jan-2018
-				$timepiece = Time::Piece->strptime(($stripped[4], '%d-%b-%Y'));
+				if ($stripped[4] ne "permanent" ) {
 
-				if ($timepiece->epoch - time < (60*60*24*$plugin->opts->critical)) {
-					$plugin->add_message(CRITICAL, $stripped[1] . ' expires on ' . $stripped[4] . ';');
-				} elsif ($timepiece->epoch - time < (60*60*24*$plugin->opts->warning)) {
-					$plugin->add_message(WARNING, $stripped[1] . ' expires on ' . $stripped[4] . ';');
+					$timepiece = Time::Piece->strptime(($stripped[4], '%d-%b-%Y'));
+
+					if ($timepiece->epoch - time < (60*60*24*$plugin->opts->critical)) {
+						$plugin->add_message(CRITICAL, $stripped[1] . ' expires on ' . $stripped[4] . ';');
+					} elsif ($timepiece->epoch - time < (60*60*24*$plugin->opts->warning)) {
+						$plugin->add_message(WARNING, $stripped[1] . ' expires on ' . $stripped[4] . ';');
+					} else {
+						$plugin->add_message(OK, $stripped[1] . ' expires on ' . $stripped[4] . ';');
+					}
 				} else {
-					$plugin->add_message(OK, $stripped[1] . ' expires on ' . $stripped[4] . ';');
+					$plugin->add_message(OK, $stripped[1] . ' never expires;');
 				}
 			}
 		}

--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -178,8 +178,7 @@ if ($plugin->opts->command eq 'state') {
 } elsif ($plugin->opts->command eq 'hwinfo') {
 	# print infos about hardware and build version
 	get_hardware_info($plugin);
-# be backwards compatible; also accept command 'performancedata'
-} elsif ($plugin->opts->command eq 'perfdata' || $plugin->opts->command eq 'performancedata') {
+} elsif ($plugin->opts->command eq 'perfdata') {
 	# print performance data of protocol stats
 	get_perfdata($plugin);
 } elsif ($plugin->opts->command eq 'interfaces') {

--- a/examples/icinga2_service_definitions.conf
+++ b/examples/icinga2_service_definitions.conf
@@ -136,4 +136,12 @@ apply Service "Perf TCP connections" {
 	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
 }
 
+// NTP
+apply Service "NTP" {
+	import "netscaler_ntp_template"
+	import "netscaler_env_details"
+
+	assign where host.vars.hw_type == "Netscaler" && host.vars.ns_env == "my_netscaler_env_a"
+}
+
 /* EOF */

--- a/examples/icinga2_service_templates.conf
+++ b/examples/icinga2_service_templates.conf
@@ -186,4 +186,17 @@ template Service "netscaler_performancedata_template" {
 	vars.netscaler_command = "performancedata"
 }
 
+// NTP status
+template Service "netscaler_ntp_template" {
+	import "generic-service"
+	import "perf_enabled"
+
+	check_command = "netscaler"
+
+	vars.netscaler_command = "ntp"
+
+	vars.warning = "o=0.03,j=100"
+	vars.critical = "o=0.05,j=200"
+}
+
 // EOF

--- a/examples/plugin_test.sh
+++ b/examples/plugin_test.sh
@@ -96,3 +96,7 @@ echo
 echo NetScaler::Perfdata::HTTP
 ./check_netscaler.pl --extra-opts=${section}@${1} -C perfdata -o nsglobalcntr -n http_tot_Requests,http_tot_Responses -x 'args=counters:http_tot_Requests;http_tot_Responses'
 echo
+
+echo NetScaler::NTP
+./check_netscaler.pl --extra-opts=${section}@${1} -C ntp -w 'o=0.03,j=100' -c 'o=0.05,j=200'
+echo


### PR DESCRIPTION
This PR adds the NTP command. I did not reinvent the wheel only reimplemented it.

Added a new command to check NTP synchronisation with configured peers.
This is pretty much a reimplementation of check_ntp_peer. Output format and
performance data should match to 99%. Also the behaviour of the warning and
critical threshold checking got matched to to check_ntp_peer.

To avoid adding a couple of extra command line options the thresholds can be
set with following options. They have to be comma separated.
* o -> offset
* s -> stratum
* j -> jitter
* t -> truechimers

example:
 -C ntp -w o=0.03,s=1,t=3,j=100 -c o=0.05,s=2,j=200,t=2

Fixes: #18 