### PR TITLE
fixed minor typo, made matches/matches_not support matching in arrays

### DIFF
--- a/check_netscaler.pl
+++ b/check_netscaler.pl
@@ -480,11 +480,11 @@ sub check_keyword
 				}
 
 				if (($type_of_string_comparison eq 'matches' && $response->{$objectname_name} eq $plugin->opts->critical) || ($type_of_string_comparison eq 'matches not' && $response->{$objectname_name} ne $plugin->opts->critical)) {
-					$plugin->add_message(CRITICAL, $plugin->opts->objecttype . '.' . $objectname_name . ': "' . $response->{$objectname_name} . '" ' . $type_of_string_comparison . ' keyword "' . $plugin->opts->critical . '";');
+					$plugin->add_message(CRITICAL, $plugin->opts->objecttype . '.' . $response->{$objectname_id} . '.' . $objectname_name . ': "' . $response->{$objectname_name} . '" ' . $type_of_string_comparison . ' keyword "' . $plugin->opts->critical . '";');
 				} elsif (($type_of_string_comparison eq 'matches' && $response->{$objectname_name} eq $plugin->opts->warning) || ($type_of_string_comparison eq 'matches not' && $response->{$objectname_name} ne $plugin->opts->warning)) {
-					$plugin->add_message(WARNING, $plugin->opts->objecttype . '.' . $objectname_name . ': "' . $response->{$objectname_name} . '" ' . $type_of_string_comparison . ' keyword "' . $plugin->opts->warning . '";');
+					$plugin->add_message(WARNING, $plugin->opts->objecttype . '.' . $response->{$objectname_id} . '.' .$objectname_name . ': "' . $response->{$objectname_name} . '" ' . $type_of_string_comparison . ' keyword "' . $plugin->opts->warning . '";');
 				} else {
-					$plugin->add_message(OK, $plugin->opts->objecttype . '.' . $objectname_name . ': '.$response->{$objectname_name}.';');
+					$plugin->add_message(OK, $plugin->opts->objecttype . '.' . $response->{$objectname_id} . '.' . $objectname_name . ': '. $response->{$objectname_name}.';');
 				}
 			}
 		}


### PR DESCRIPTION
For monitoring of sdx appliances it is feasible to be able to use matches/matches_not and the "dot notation" of check-netscaler. This PR should (my perl is a bit rusty at least) achieve this goal.

edit: replaced "instances" with "appliances"