### PR TITLE
Add netscaler prefix to variable names for critical and warning

### DIFF
--- a/examples/icinga2_command.conf
+++ b/examples/icinga2_command.conf
@@ -15,8 +15,8 @@ object CheckCommand "netscaler" {
 		"-o" = "$netscaler_objecttype$"
 		"-n" = "$netscaler_objectname$"
 		"-e" = "$netscaler_endpoint$"
-		"-w" = "$warning$"
-		"-c" = "$critical$"
+		"-w" = "$netscaler_warning$"
+		"-c" = "$netscaler_critical$"
 		"-t" = "$netscaler_timeout$"
 	}
 


### PR DESCRIPTION
Standard practice in the Icinga Template Library is to prefix
the names of the variables with the name of the check.