### PR TITLE
Allow dynamic host address variable in Icinga2 command definition

### DIFF
--- a/examples/icinga2_command.conf
+++ b/examples/icinga2_command.conf
@@ -4,7 +4,7 @@ object CheckCommand "netscaler" {
         command = [ PluginDir + "/check_netscaler.pl" ]
 
         arguments = {
-		"-H" = "$address$"
+		"-H" = "$netscaler_address$"
 		"-u" = "$netscaler_user$"
 		"-p" = "$netscaler_password$"
 		"--ssl" = {
@@ -19,5 +19,7 @@ object CheckCommand "netscaler" {
 		"-c" = "$netscaler_critical$"
 		"-t" = "$netscaler_timeout$"
 	}
+
+	vars.netscaler_address = "$address$"
 
 }


### PR DESCRIPTION
This minor modification in the icinga2 command example allows dynamic usage of the Netscaler destination address. 

Current situation: The $address$ is fixed, meaning the IP address of the Netscaler will be the IP address of the Host Object on which the check is configured as service. But there might be situations that you want to place the service to a (generic) host object. 

By merging this PR: The -H parameter now uses a variable "netscaler_address" which by default uses $address$ as value. So this is de facto the same as before but just using an additional variable.
But this now allows that the service can override the destination IP address of the Netscaler gateway. Simple Example:

```
# Check Netscaler 1, Memory Usage
object Service "Netscaler 1 Memory Usage" {
  import "service-60s-normal"
  host_name = "Netscaler-Master"
  check_command = "netscaler"
  vars.netscaler_address = "10.10.10.11"
  vars.netscaler_ssl = true
  vars.netscaler_user = "nsroot"
  vars.netscaler_password = "secret"
  vars.netscaler_command = "above"
  vars.netscaler_objecttype = "system"
  vars.netscaler_objectname = "memusagepcnt"
}

# Check Netscaler 2, Memory Usage
object Service "Netscaler 2 Memory Usage" {
  import "service-60s-normal"
  host_name = "Netscaler-Master"
  check_command = "netscaler"
  vars.netscaler_address = "10.10.10.12"
  vars.netscaler_ssl = true
  vars.netscaler_user = "nsroot"
  vars.netscaler_password = "secret"
  vars.netscaler_command = "above"
  vars.netscaler_objecttype = "system"
  vars.netscaler_objectname = "memusagepcnt"
}
```