### PR TITLE
ci: update github actions and enable renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,16 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "semanticCommitType": "ci"
+      "semanticCommitType": "ci",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["python"],
+      "semanticCommitType": "fix",
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Update GitHub Actions dependencies to latest versions
- Enable Renovate automerge for GitHub Actions dependencies
- Add separate rule for Python runtime updates with `fix:` semantic commit type

## Changes
- `.github/workflows/*.yml`: Updated action versions
- `renovate.json`: Added automerge config for GitHub Actions and Python runtime