### PR TITLE
feat: improve lbvserver state checks and health perfdata

### DIFF
--- a/check_netscaler/client/session.py
+++ b/check_netscaler/client/session.py
@@ -5,6 +5,8 @@ Session management for NITRO API
 from typing import Optional
 
 import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
 from check_netscaler.client.exceptions import (
     NITROAuthenticationError,
@@ -44,6 +46,8 @@ class NITROSession:
         self.ssl = ssl
         self.timeout = timeout
         self.verify_ssl = verify_ssl
+        if self.ssl and not self.verify_ssl:
+            urllib3.disable_warnings(InsecureRequestWarning)
 
         # Determine port
         if port:

--- a/check_netscaler/commands/perfdata.py
+++ b/check_netscaler/commands/perfdata.py
@@ -16,6 +16,14 @@ from check_netscaler.constants import (
 class PerfdataCommand(BaseCommand):
     """Collect arbitrary performance data fields"""
 
+    NS_CONNECTION_SUMMARY_FIELDS = {
+        "txmbitsrate": ("TX", "MBits/s"),
+        "rxmbitsrate": ("RX", "MBits/s"),
+        "tcpcurclientconnestablished": ("ClientConn", ""),
+        "tcpcurserverconnestablished": ("ServerConn", ""),
+        "ssltransactionsrate": ("SSLConn", "C/s"),
+    }
+
     def execute(self) -> CheckResult:
         """
         Execute perfdata check
@@ -156,9 +164,7 @@ class PerfdataCommand(BaseCommand):
                 )
 
             # Build message
-            message = f"perfdata: collected {len(perfdata)} metrics from {objecttype}"
-            if objectname:
-                message += f" ({objectname})"
+            message = self._build_message(objecttype, response, fields, perfdata)
 
             return CheckResult(
                 status=STATE_OK,
@@ -176,3 +182,38 @@ class PerfdataCommand(BaseCommand):
                 status=STATE_UNKNOWN,
                 message=f"Unexpected error: {str(e)}",
             )
+
+    def _build_message(self, objecttype: str, response, fields, perfdata: Dict[str, float]) -> str:
+        """Build a useful status summary for perfdata checks."""
+        if objecttype == "ns":
+            summary = self._build_ns_summary(response, fields)
+            if summary:
+                return summary
+
+        return f"perfdata: collected {len(perfdata)} metrics from {objecttype}"
+
+    def _build_ns_summary(self, response, fields) -> str:
+        """Build legacy-style ns connection summary when the expected metrics are requested."""
+        if len(response) != 1 or not isinstance(response[0], dict):
+            return ""
+
+        obj = response[0]
+        parts = []
+
+        for field in fields:
+            if field not in self.NS_CONNECTION_SUMMARY_FIELDS or field not in obj:
+                continue
+
+            try:
+                value = float(obj[field])
+            except (TypeError, ValueError):
+                continue
+
+            label, suffix = self.NS_CONNECTION_SUMMARY_FIELDS[field]
+            value_text = f"{value:g}"
+            if suffix:
+                parts.append(f"{label} {value_text} {suffix}")
+            else:
+                parts.append(f"{label} {value_text}")
+
+        return ", ".join(parts)

--- a/check_netscaler/commands/state.py
+++ b/check_netscaler/commands/state.py
@@ -3,7 +3,7 @@ State check command - monitors vServer, service, servicegroup, and server states
 """
 
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from check_netscaler.client.exceptions import NITROAPIError, NITROResourceNotFoundError
 from check_netscaler.commands.base import BaseCommand, CheckResult
@@ -247,6 +247,7 @@ class StateCommand(BaseCommand):
         warning_objects = []
         long_output = []
         perfdata = {}
+        warning_threshold, critical_threshold = self._get_lbvserver_health_thresholds()
 
         for obj in objects:
             name = obj.get("name", "unknown")
@@ -260,11 +261,11 @@ class StateCommand(BaseCommand):
             elif health is None:
                 ok_count += 1
                 status_str = "OK"
-            elif health == 0:
+            elif health <= critical_threshold:
                 critical_count += 1
                 status_str = "CRITICAL"
                 critical_objects.append(name)
-            elif health < 100:
+            elif health < warning_threshold:
                 warning_count += 1
                 status_str = "WARNING"
                 warning_objects.append(name)
@@ -375,6 +376,39 @@ class StateCommand(BaseCommand):
         if float(health).is_integer():
             return f"{int(health)}%"
         return f"{health:g}%"
+
+    def _get_lbvserver_health_thresholds(self) -> Tuple[float, float]:
+        """Return warning and critical health thresholds for lbvserver checks."""
+        warning = self._parse_lbvserver_health_threshold(getattr(self.args, "warning", None), 100.0)
+        critical = self._parse_lbvserver_health_threshold(
+            getattr(self.args, "critical", None), 0.0
+        )
+
+        if critical > warning:
+            raise ValueError(
+                f"Invalid lbvserver health thresholds: critical ({critical:g}) cannot exceed warning ({warning:g})"
+            )
+
+        return warning, critical
+
+    def _parse_lbvserver_health_threshold(
+        self, value: Optional[str], default: float
+    ) -> float:
+        """Parse lbvserver health threshold from CLI, preserving legacy defaults."""
+        if value is None:
+            return default
+
+        try:
+            threshold = float(value)
+        except ValueError as exc:
+            raise ValueError(f"Invalid lbvserver health threshold: {value}") from exc
+
+        if threshold < 0 or threshold > 100:
+            raise ValueError(
+                f"Invalid lbvserver health threshold: {threshold:g} (must be between 0 and 100)"
+            )
+
+        return threshold
 
     def _build_message(
         self,

--- a/check_netscaler/commands/state.py
+++ b/check_netscaler/commands/state.py
@@ -245,7 +245,7 @@ class StateCommand(BaseCommand):
             details = state if health_text is None else f"{state}, health={health_text}"
             long_output.append(f"[{status_str}] {name}: {details}")
 
-            if health is not None:
+            if total > 1 and health is not None:
                 perfdata[f"{name}.health"] = self._build_lbvserver_health_perfdata(
                     health, warning_threshold, critical_threshold
                 )
@@ -279,7 +279,6 @@ class StateCommand(BaseCommand):
 
         if total == 1:
             health = self._get_lbvserver_health(objects[0])
-            health_text = self._format_health(health)
             if health is not None:
                 perfdata["health"] = self._build_lbvserver_health_perfdata(
                     health, warning_threshold, critical_threshold

--- a/check_netscaler/commands/state.py
+++ b/check_netscaler/commands/state.py
@@ -277,8 +277,10 @@ class StateCommand(BaseCommand):
             details = state if health_text is None else f"{state}, health={health_text}"
             long_output.append(f"[{status_str}] {name}: {details}")
 
-            if health_text is not None:
-                perfdata[f"{name}.health"] = health_text
+            if health is not None:
+                perfdata[f"{name}.health"] = self._build_lbvserver_health_perfdata(
+                    health, warning_threshold, critical_threshold
+                )
 
         if critical_count > 0:
             overall_status = STATE_CRITICAL
@@ -310,8 +312,10 @@ class StateCommand(BaseCommand):
         if total == 1:
             health = self._get_lbvserver_health(objects[0])
             health_text = self._format_health(health)
-            if health_text is not None:
-                perfdata["health"] = health_text
+            if health is not None:
+                perfdata["health"] = self._build_lbvserver_health_perfdata(
+                    health, warning_threshold, critical_threshold
+                )
 
         return CheckResult(
             status=overall_status,
@@ -376,6 +380,19 @@ class StateCommand(BaseCommand):
         if float(health).is_integer():
             return f"{int(health)}%"
         return f"{health:g}%"
+
+    def _build_lbvserver_health_perfdata(
+        self, health: float, warning_threshold: float, critical_threshold: float
+    ) -> Dict[str, str]:
+        """Build perfdata metadata for lbvserver health."""
+        return {
+            "value": f"{health:g}",
+            "uom": "%",
+            "warn": f"{warning_threshold:g}",
+            "crit": f"{critical_threshold:g}",
+            "min": "0",
+            "max": "100",
+        }
 
     def _get_lbvserver_health_thresholds(self) -> Tuple[float, float]:
         """Return warning and critical health thresholds for lbvserver checks."""

--- a/check_netscaler/commands/state.py
+++ b/check_netscaler/commands/state.py
@@ -46,7 +46,7 @@ class StateCommand(BaseCommand):
             # Extract objects from response
             objects = self._extract_objects(data, objecttype)
 
-            if objecttype == "lbvserver":
+            if objecttype == "lbvserver" and self._lbvserver_health_check_enabled():
                 objects = self._merge_lbvserver_config(objects, objectname)
 
             if not objects:
@@ -133,7 +133,7 @@ class StateCommand(BaseCommand):
         Returns:
             CheckResult with aggregated status
         """
-        if objecttype == "lbvserver":
+        if objecttype == "lbvserver" and self._lbvserver_health_check_enabled():
             return self._evaluate_lbvserver_states(objects)
 
         total = len(objects)
@@ -221,7 +221,9 @@ class StateCommand(BaseCommand):
             return objects
 
         config_by_name = {
-            obj.get("name"): obj for obj in config_objects if isinstance(obj, dict) and obj.get("name")
+            obj.get("name"): obj
+            for obj in config_objects
+            if isinstance(obj, dict) and obj.get("name")
         }
 
         merged_objects = []
@@ -324,6 +326,13 @@ class StateCommand(BaseCommand):
             long_output=long_output if len(objects) > 1 else [],
         )
 
+    def _lbvserver_health_check_enabled(self) -> bool:
+        """Return whether lbvserver health evaluation is enabled via thresholds."""
+        return (
+            getattr(self.args, "warning", None) is not None
+            or getattr(self.args, "critical", None) is not None
+        )
+
     def _build_lbvserver_message(
         self,
         objects: List[Dict],
@@ -397,9 +406,7 @@ class StateCommand(BaseCommand):
     def _get_lbvserver_health_thresholds(self) -> Tuple[float, float]:
         """Return warning and critical health thresholds for lbvserver checks."""
         warning = self._parse_lbvserver_health_threshold(getattr(self.args, "warning", None), 100.0)
-        critical = self._parse_lbvserver_health_threshold(
-            getattr(self.args, "critical", None), 0.0
-        )
+        critical = self._parse_lbvserver_health_threshold(getattr(self.args, "critical", None), 0.0)
 
         if critical > warning:
             raise ValueError(
@@ -408,9 +415,7 @@ class StateCommand(BaseCommand):
 
         return warning, critical
 
-    def _parse_lbvserver_health_threshold(
-        self, value: Optional[str], default: float
-    ) -> float:
+    def _parse_lbvserver_health_threshold(self, value: Optional[str], default: float) -> float:
         """Parse lbvserver health threshold from CLI, preserving legacy defaults."""
         if value is None:
             return default

--- a/check_netscaler/commands/state.py
+++ b/check_netscaler/commands/state.py
@@ -5,7 +5,7 @@ State check command - monitors vServer, service, servicegroup, and server states
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from check_netscaler.client.exceptions import NITROAPIError, NITROResourceNotFoundError
+from check_netscaler.client.exceptions import NITROResourceNotFoundError
 from check_netscaler.commands.base import BaseCommand, CheckResult
 from check_netscaler.constants import (
     STATE_CRITICAL,
@@ -45,9 +45,6 @@ class StateCommand(BaseCommand):
 
             # Extract objects from response
             objects = self._extract_objects(data, objecttype)
-
-            if objecttype == "lbvserver" and self._lbvserver_health_check_enabled():
-                objects = self._merge_lbvserver_config(objects, objectname)
 
             if not objects:
                 return CheckResult(
@@ -206,39 +203,8 @@ class StateCommand(BaseCommand):
             long_output=long_output if len(objects) > 1 else [],
         )
 
-    def _merge_lbvserver_config(self, objects: List[Dict], objectname: Optional[str]) -> List[Dict]:
-        """Merge lbvserver config fields like effectivestate into stat objects."""
-        try:
-            config_data = self.client.get_config("lbvserver", objectname)
-        except NITROAPIError:
-            return objects
-
-        if not isinstance(config_data, dict):
-            return objects
-
-        config_objects = self._extract_objects(config_data, "lbvserver")
-        if not config_objects:
-            return objects
-
-        config_by_name = {
-            obj.get("name"): obj
-            for obj in config_objects
-            if isinstance(obj, dict) and obj.get("name")
-        }
-
-        merged_objects = []
-        for obj in objects:
-            if not isinstance(obj, dict):
-                merged_objects.append(obj)
-                continue
-
-            config_obj = config_by_name.get(obj.get("name"), {})
-            merged_objects.append({**config_obj, **obj})
-
-        return merged_objects
-
     def _evaluate_lbvserver_states(self, objects: List[Dict]) -> CheckResult:
-        """Evaluate lbvserver status using effective state and health percentage."""
+        """Evaluate lbvserver status using stat state and health percentage."""
         total = len(objects)
         ok_count = 0
         warning_count = 0
@@ -343,7 +309,7 @@ class StateCommand(BaseCommand):
         critical_objects: List[str],
         warning_objects: List[str],
     ) -> str:
-        """Build lbvserver-specific messages with effective state and health."""
+        """Build lbvserver-specific messages with state and health."""
         total = len(objects)
         if total == 1:
             obj = objects[0]
@@ -366,8 +332,8 @@ class StateCommand(BaseCommand):
         )
 
     def _get_lbvserver_state(self, obj: Dict[str, Any]) -> str:
-        """Prefer lbvserver effectivestate when available."""
-        state = obj.get("effectivestate") or obj.get("state") or "UNKNOWN"
+        """Return lbvserver state from the stat response."""
+        state = obj.get("state") or "UNKNOWN"
         return str(state).upper()
 
     def _get_lbvserver_health(self, obj: Dict[str, Any]) -> Optional[float]:

--- a/check_netscaler/commands/state.py
+++ b/check_netscaler/commands/state.py
@@ -3,9 +3,9 @@ State check command - monitors vServer, service, servicegroup, and server states
 """
 
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from check_netscaler.client.exceptions import NITROResourceNotFoundError
+from check_netscaler.client.exceptions import NITROAPIError, NITROResourceNotFoundError
 from check_netscaler.commands.base import BaseCommand, CheckResult
 from check_netscaler.constants import (
     STATE_CRITICAL,
@@ -45,6 +45,9 @@ class StateCommand(BaseCommand):
 
             # Extract objects from response
             objects = self._extract_objects(data, objecttype)
+
+            if objecttype == "lbvserver":
+                objects = self._merge_lbvserver_config(objects, objectname)
 
             if not objects:
                 return CheckResult(
@@ -130,6 +133,9 @@ class StateCommand(BaseCommand):
         Returns:
             CheckResult with aggregated status
         """
+        if objecttype == "lbvserver":
+            return self._evaluate_lbvserver_states(objects)
+
         total = len(objects)
         ok_count = 0
         warning_count = 0
@@ -199,6 +205,176 @@ class StateCommand(BaseCommand):
             perfdata=perfdata,
             long_output=long_output if len(objects) > 1 else [],
         )
+
+    def _merge_lbvserver_config(self, objects: List[Dict], objectname: Optional[str]) -> List[Dict]:
+        """Merge lbvserver config fields like effectivestate into stat objects."""
+        try:
+            config_data = self.client.get_config("lbvserver", objectname)
+        except NITROAPIError:
+            return objects
+
+        if not isinstance(config_data, dict):
+            return objects
+
+        config_objects = self._extract_objects(config_data, "lbvserver")
+        if not config_objects:
+            return objects
+
+        config_by_name = {
+            obj.get("name"): obj for obj in config_objects if isinstance(obj, dict) and obj.get("name")
+        }
+
+        merged_objects = []
+        for obj in objects:
+            if not isinstance(obj, dict):
+                merged_objects.append(obj)
+                continue
+
+            config_obj = config_by_name.get(obj.get("name"), {})
+            merged_objects.append({**config_obj, **obj})
+
+        return merged_objects
+
+    def _evaluate_lbvserver_states(self, objects: List[Dict]) -> CheckResult:
+        """Evaluate lbvserver status using effective state and health percentage."""
+        total = len(objects)
+        ok_count = 0
+        warning_count = 0
+        critical_count = 0
+        unknown_count = 0
+
+        critical_objects = []
+        warning_objects = []
+        long_output = []
+        perfdata = {}
+
+        for obj in objects:
+            name = obj.get("name", "unknown")
+            state = self._get_lbvserver_state(obj)
+            health = self._get_lbvserver_health(obj)
+
+            if state != "UP":
+                critical_count += 1
+                status_str = "CRITICAL"
+                critical_objects.append(name)
+            elif health is None:
+                ok_count += 1
+                status_str = "OK"
+            elif health == 0:
+                critical_count += 1
+                status_str = "CRITICAL"
+                critical_objects.append(name)
+            elif health < 100:
+                warning_count += 1
+                status_str = "WARNING"
+                warning_objects.append(name)
+            else:
+                ok_count += 1
+                status_str = "OK"
+
+            health_text = self._format_health(health)
+            details = state if health_text is None else f"{state}, health={health_text}"
+            long_output.append(f"[{status_str}] {name}: {details}")
+
+            if health_text is not None:
+                perfdata[f"{name}.health"] = health_text
+
+        if critical_count > 0:
+            overall_status = STATE_CRITICAL
+        elif warning_count > 0 or unknown_count > 0:
+            overall_status = STATE_WARNING
+        else:
+            overall_status = STATE_OK
+
+        message = self._build_lbvserver_message(
+            objects,
+            ok_count,
+            warning_count,
+            critical_count,
+            unknown_count,
+            critical_objects,
+            warning_objects,
+        )
+
+        perfdata.update(
+            {
+                "total": total,
+                "ok": ok_count,
+                "warning": warning_count,
+                "critical": critical_count,
+                "unknown": unknown_count,
+            }
+        )
+
+        if total == 1:
+            health = self._get_lbvserver_health(objects[0])
+            health_text = self._format_health(health)
+            if health_text is not None:
+                perfdata["health"] = health_text
+
+        return CheckResult(
+            status=overall_status,
+            message=message,
+            perfdata=perfdata,
+            long_output=long_output if len(objects) > 1 else [],
+        )
+
+    def _build_lbvserver_message(
+        self,
+        objects: List[Dict],
+        ok: int,
+        warning: int,
+        critical: int,
+        unknown: int,
+        critical_objects: List[str],
+        warning_objects: List[str],
+    ) -> str:
+        """Build lbvserver-specific messages with effective state and health."""
+        total = len(objects)
+        if total == 1:
+            obj = objects[0]
+            name = obj.get("name", "unknown")
+            state = self._get_lbvserver_state(obj)
+            health_text = self._format_health(self._get_lbvserver_health(obj))
+            if health_text is None:
+                return f"{name} state: {state}"
+            return f"{name} state: {state}, Health: {health_text}"
+
+        return self._build_message(
+            "lbvserver",
+            total,
+            ok,
+            warning,
+            critical,
+            unknown,
+            critical_objects,
+            warning_objects,
+        )
+
+    def _get_lbvserver_state(self, obj: Dict[str, Any]) -> str:
+        """Prefer lbvserver effectivestate when available."""
+        state = obj.get("effectivestate") or obj.get("state") or "UNKNOWN"
+        return str(state).upper()
+
+    def _get_lbvserver_health(self, obj: Dict[str, Any]) -> Optional[float]:
+        """Return lbvserver health percentage when provided by the API."""
+        for field in ("health", "vslbhealth"):
+            value = obj.get(field)
+            if value is None:
+                continue
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _format_health(self, health: Optional[float]) -> Optional[str]:
+        """Format health as a percentage without trailing decimals when possible."""
+        if health is None:
+            return None
+        if float(health).is_integer():
+            return f"{int(health)}%"
+        return f"{health:g}%"
 
     def _build_message(
         self,

--- a/check_netscaler/output/nagios.py
+++ b/check_netscaler/output/nagios.py
@@ -95,6 +95,20 @@ class NagiosOutput:
             else:
                 label = key
 
+            if isinstance(value, dict):
+                perfdata_parts.append(
+                    NagiosOutput.format_perfdata_item(
+                        label=label,
+                        value=value.get("value", ""),
+                        uom=value.get("uom", ""),
+                        warn=value.get("warn"),
+                        crit=value.get("crit"),
+                        min_val=value.get("min"),
+                        max_val=value.get("max"),
+                    )
+                )
+                continue
+
             # Format value
             # Nagios perfdata format: 'label'=value[UOM];[warn];[crit];[min];[max]
             perfdata_str = f"'{label}'={value}"

--- a/docs/commands/perfdata.md
+++ b/docs/commands/perfdata.md
@@ -107,14 +107,26 @@ check_netscaler -C perfdata -o system \
   -n tcpcurestablishedconn,tcpcurserverconn,tcpcurclientconn
 ```
 
-### 4. SSL/TLS statistics
+### 4. NetScaler connection overview
+
+```bash
+check_netscaler -C perfdata -o ns \
+  -n txmbitsrate,rxmbitsrate,tcpcurclientconnestablished,tcpcurserverconnestablished,ssltransactionsrate
+```
+
+**Output:**
+```
+OK: TX 12.5 MBits/s, RX 34.5 MBits/s, ClientConn 123, ServerConn 456, SSLConn 7 C/s | 'txmbitsrate'=12.5;; 'rxmbitsrate'=34.5;; 'tcpcurclientconnestablished'=123;; 'tcpcurserverconnestablished'=456;; 'ssltransactionsrate'=7;;
+```
+
+### 5. SSL/TLS statistics
 
 ```bash
 check_netscaler -C perfdata -o ssl \
   -n ssltotsessions,ssltothwsessions,ssltotswsessions
 ```
 
-### 5. Cache statistics
+### 6. Cache statistics
 
 ```bash
 check_netscaler -C perfdata -o cache \

--- a/docs/commands/state.md
+++ b/docs/commands/state.md
@@ -43,7 +43,7 @@ check_netscaler -C state -o lbvserver -n web_lb
 
 **Output:**
 ```
-OK: web_lb state: UP, Health: 100% | 'web_lb.health'=100%;; 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;;
+OK: web_lb state: UP, Health: 100% | 'web_lb.health'=100%;100;0;0;100 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;100;0;0;100
 ```
 
 ### Check all services
@@ -173,7 +173,7 @@ For `lbvserver`, the command prefers `effectivestate` when available and evaluat
 For `lbvserver`, the command outputs summary counters and health percentage:
 
 ```
-| 'web_lb.health'=100%;; 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;;
+| 'web_lb.health'=100%;100;0;0;100 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;100;0;0;100
 ```
 
 Other object types keep the existing generic summary perfdata.

--- a/docs/commands/state.md
+++ b/docs/commands/state.md
@@ -134,6 +134,23 @@ CRITICAL: lbvserver is UP; Backup vServer active: api_lb_backup | total=1 ok=1 w
 - Alert when traffic is being served by backup infrastructure
 - Track when primary services have been restored (backup no longer active)
 
+### Custom lbvserver health thresholds
+
+For `state -o lbvserver`, you can override the default health handling with `-w` and `-c`:
+
+```bash
+check_netscaler -C state -o lbvserver -n web_lb -w 95 -c 80
+```
+
+This means:
+- `health <= 80` -> `CRITICAL`
+- `health < 95` -> `WARNING`
+- `health >= 95` with `effectivestate == UP` -> `OK`
+
+If you omit these thresholds, the legacy-compatible defaults are still used:
+- warning below `100`
+- critical at or below `0`
+
 ## State Mappings
 
 ### vServer States
@@ -142,7 +159,7 @@ CRITICAL: lbvserver is UP; Backup vServer active: api_lb_backup | total=1 ok=1 w
 - `effectivestate == UP` and `health < 100` - WARNING
 - `effectivestate == UP` and `health == 100` - OK
 
-For `lbvserver`, the command now prefers `effectivestate` when available and also evaluates the vServer health percentage from the NITRO API.
+For `lbvserver`, the command prefers `effectivestate` when available and evaluates the vServer health percentage from the NITRO API.
 
 ### Service States
 - `UP` - OK

--- a/docs/commands/state.md
+++ b/docs/commands/state.md
@@ -145,7 +145,7 @@ check_netscaler -C state -o lbvserver -n web_lb -w 95 -c 80
 This means:
 - `health <= 80` -> `CRITICAL`
 - `health < 95` -> `WARNING`
-- `health >= 95` with `effectivestate == UP` -> `OK`
+- `health >= 95` with `state == UP` -> `OK`
 
 If you omit both thresholds, the command keeps the legacy behavior and only checks the lbvserver `state`.
 
@@ -153,12 +153,12 @@ If you omit both thresholds, the command keeps the legacy behavior and only chec
 
 ### vServer States
 - default: `state` is evaluated exactly as before (`UP` = OK, `DOWN` = CRITICAL, `OUT OF SERVICE` = WARNING)
-- with `-w`/`-c`: `effectivestate != UP` - CRITICAL
-- with `-w`/`-c`: `effectivestate == UP` and `health <= critical` - CRITICAL
-- with `-w`/`-c`: `effectivestate == UP` and `health < warning` - WARNING
-- with `-w`/`-c`: `effectivestate == UP` and `health >= warning` - OK
+- with `-w`/`-c`: `state != UP` - CRITICAL
+- with `-w`/`-c`: `state == UP` and `health <= critical` - CRITICAL
+- with `-w`/`-c`: `state == UP` and `health < warning` - WARNING
+- with `-w`/`-c`: `state == UP` and `health >= warning` - OK
 
-When health thresholds are enabled, the command prefers `effectivestate` when available and evaluates the vServer health percentage from the NITRO API.
+When health thresholds are enabled, the command evaluates only the `stat` response fields already returned by the NITRO API: `state` and `vslbhealth`.
 
 ### Service States
 - `UP` - OK

--- a/docs/commands/state.md
+++ b/docs/commands/state.md
@@ -43,7 +43,7 @@ check_netscaler -C state -o lbvserver -n web_lb
 
 **Output:**
 ```
-OK: web_lb state: UP, Health: 100% | 'web_lb.health'=100%;100;0;0;100 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;100;0;0;100
+OK: lbvserver is UP | 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;;
 ```
 
 ### Check all services
@@ -136,7 +136,7 @@ CRITICAL: lbvserver is UP; Backup vServer active: api_lb_backup | total=1 ok=1 w
 
 ### Custom lbvserver health thresholds
 
-For `state -o lbvserver`, you can override the default health handling with `-w` and `-c`:
+For `state -o lbvserver`, health percentage evaluation is opt-in and only activates when you pass `-w` or `-c`:
 
 ```bash
 check_netscaler -C state -o lbvserver -n web_lb -w 95 -c 80
@@ -147,19 +147,18 @@ This means:
 - `health < 95` -> `WARNING`
 - `health >= 95` with `effectivestate == UP` -> `OK`
 
-If you omit these thresholds, the legacy-compatible defaults are still used:
-- warning below `100`
-- critical at or below `0`
+If you omit both thresholds, the command keeps the legacy behavior and only checks the lbvserver `state`.
 
 ## State Mappings
 
 ### vServer States
-- `effectivestate != UP` - CRITICAL
-- `effectivestate == UP` and `health == 0` - CRITICAL
-- `effectivestate == UP` and `health < 100` - WARNING
-- `effectivestate == UP` and `health == 100` - OK
+- default: `state` is evaluated exactly as before (`UP` = OK, `DOWN` = CRITICAL, `OUT OF SERVICE` = WARNING)
+- with `-w`/`-c`: `effectivestate != UP` - CRITICAL
+- with `-w`/`-c`: `effectivestate == UP` and `health <= critical` - CRITICAL
+- with `-w`/`-c`: `effectivestate == UP` and `health < warning` - WARNING
+- with `-w`/`-c`: `effectivestate == UP` and `health >= warning` - OK
 
-For `lbvserver`, the command prefers `effectivestate` when available and evaluates the vServer health percentage from the NITRO API.
+When health thresholds are enabled, the command prefers `effectivestate` when available and evaluates the vServer health percentage from the NITRO API.
 
 ### Service States
 - `UP` - OK
@@ -170,7 +169,7 @@ For `lbvserver`, the command prefers `effectivestate` when available and evaluat
 
 ## Performance Data
 
-For `lbvserver`, the command outputs summary counters and health percentage:
+When `-w` or `-c` enables health checks for `lbvserver`, the command outputs summary counters and health percentage:
 
 ```
 | 'web_lb.health'=100%;100;0;0;100 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;100;0;0;100

--- a/docs/commands/state.md
+++ b/docs/commands/state.md
@@ -43,7 +43,7 @@ check_netscaler -C state -o lbvserver -n web_lb
 
 **Output:**
 ```
-OK: lbvserver web_lb is UP | web_lb.activeconnections=42
+OK: web_lb state: UP, Health: 100% | 'web_lb.health'=100%;; 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;;
 ```
 
 ### Check all services
@@ -137,10 +137,12 @@ CRITICAL: lbvserver is UP; Backup vServer active: api_lb_backup | total=1 ok=1 w
 ## State Mappings
 
 ### vServer States
-- `UP` - OK (vServer is operational)
-- `DOWN` - CRITICAL (vServer is down)
-- `OUT OF SERVICE` - WARNING (administratively disabled)
-- `UNKNOWN` - UNKNOWN (state cannot be determined)
+- `effectivestate != UP` - CRITICAL
+- `effectivestate == UP` and `health == 0` - CRITICAL
+- `effectivestate == UP` and `health < 100` - WARNING
+- `effectivestate == UP` and `health == 100` - OK
+
+For `lbvserver`, the command now prefers `effectivestate` when available and also evaluates the vServer health percentage from the NITRO API.
 
 ### Service States
 - `UP` - OK
@@ -150,6 +152,14 @@ CRITICAL: lbvserver is UP; Backup vServer active: api_lb_backup | total=1 ok=1 w
 - `UNKNOWN` - UNKNOWN
 
 ## Performance Data
+
+For `lbvserver`, the command outputs summary counters and health percentage:
+
+```
+| 'web_lb.health'=100%;; 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;;
+```
+
+Other object types keep the existing generic summary perfdata.
 
 The command outputs performance data for active connections:
 

--- a/docs/commands/state.md
+++ b/docs/commands/state.md
@@ -172,7 +172,7 @@ When health thresholds are enabled, the command evaluates only the `stat` respon
 When `-w` or `-c` enables health checks for `lbvserver`, the command outputs summary counters and health percentage:
 
 ```
-| 'web_lb.health'=100%;100;0;0;100 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;100;0;0;100
+| 'total'=1;; 'ok'=1;; 'warning'=0;; 'critical'=0;; 'unknown'=0;; 'health'=100%;100;0;0;100
 ```
 
 Other object types keep the existing generic summary perfdata.

--- a/tests/integration/test_state_integration.py
+++ b/tests/integration/test_state_integration.py
@@ -84,6 +84,7 @@ class TestStateCommandIntegration:
             assert result.perfdata["health"]["value"] == "95"
             assert result.perfdata["health"]["warn"] == "100"
             assert result.perfdata["health"]["crit"] == "0"
+            assert "lb_ssl.health" not in result.perfdata
 
     def test_state_check_lbvserver_down(self, mock_nitro_server):
         """Test checking state of DOWN load balancer"""

--- a/tests/integration/test_state_integration.py
+++ b/tests/integration/test_state_integration.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 from check_netscaler.client import NITROClient
 from check_netscaler.commands.state import StateCommand
-from check_netscaler.constants import STATE_CRITICAL, STATE_OK
+from check_netscaler.constants import STATE_CRITICAL, STATE_OK, STATE_WARNING
 
 
 class TestStateCommandIntegration:
@@ -31,7 +31,31 @@ class TestStateCommandIntegration:
             result = command.execute()
 
             assert result.status == STATE_OK
-            assert result.message == "lbvserver is UP"
+            assert result.message == "lb_web state: UP, Health: 100%"
+
+    def test_state_check_lbvserver_health_warning(self, mock_nitro_server):
+        """Test checking lbvserver health below 100%."""
+        with NITROClient(
+            hostname=mock_nitro_server.host,
+            port=mock_nitro_server.port,
+            username="nsroot",
+            password="nsroot",
+            ssl=False,
+        ) as client:
+            args = Namespace(
+                command="state",
+                objecttype="lbvserver",
+                objectname="lb_ssl",
+                filter=None,
+                limit=None,
+            )
+
+            command = StateCommand(client, args)
+            result = command.execute()
+
+            assert result.status == STATE_WARNING
+            assert result.message == "lb_ssl state: UP, Health: 95%"
+            assert result.perfdata["health"] == "95%"
 
     def test_state_check_lbvserver_down(self, mock_nitro_server):
         """Test checking state of DOWN load balancer"""
@@ -54,9 +78,7 @@ class TestStateCommandIntegration:
             result = command.execute()
 
             assert result.status == STATE_CRITICAL
-            assert "CRITICAL" in result.message
-            assert "lb_down" in result.message
-            assert "1/1" in result.message
+            assert result.message == "lb_down state: DOWN, Health: 0%"
 
     def test_state_check_all_lbvservers(self, mock_nitro_server):
         """Test checking all load balancers"""

--- a/tests/integration/test_state_integration.py
+++ b/tests/integration/test_state_integration.py
@@ -55,7 +55,9 @@ class TestStateCommandIntegration:
 
             assert result.status == STATE_WARNING
             assert result.message == "lb_ssl state: UP, Health: 95%"
-            assert result.perfdata["health"] == "95%"
+            assert result.perfdata["health"]["value"] == "95"
+            assert result.perfdata["health"]["warn"] == "100"
+            assert result.perfdata["health"]["crit"] == "0"
 
     def test_state_check_lbvserver_down(self, mock_nitro_server):
         """Test checking state of DOWN load balancer"""

--- a/tests/integration/test_state_integration.py
+++ b/tests/integration/test_state_integration.py
@@ -31,10 +31,10 @@ class TestStateCommandIntegration:
             result = command.execute()
 
             assert result.status == STATE_OK
-            assert result.message == "lb_web state: UP, Health: 100%"
+            assert result.message == "lbvserver is UP"
 
-    def test_state_check_lbvserver_health_warning(self, mock_nitro_server):
-        """Test checking lbvserver health below 100%."""
+    def test_state_check_lbvserver_ignores_health_by_default(self, mock_nitro_server):
+        """Test lbvserver health does not affect status without thresholds."""
         with NITROClient(
             hostname=mock_nitro_server.host,
             port=mock_nitro_server.port,
@@ -48,6 +48,32 @@ class TestStateCommandIntegration:
                 objectname="lb_ssl",
                 filter=None,
                 limit=None,
+            )
+
+            command = StateCommand(client, args)
+            result = command.execute()
+
+            assert result.status == STATE_OK
+            assert result.message == "lbvserver is UP"
+            assert "health" not in result.perfdata
+
+    def test_state_check_lbvserver_health_warning(self, mock_nitro_server):
+        """Test checking lbvserver health below warning threshold."""
+        with NITROClient(
+            hostname=mock_nitro_server.host,
+            port=mock_nitro_server.port,
+            username="nsroot",
+            password="nsroot",
+            ssl=False,
+        ) as client:
+            args = Namespace(
+                command="state",
+                objecttype="lbvserver",
+                objectname="lb_ssl",
+                filter=None,
+                limit=None,
+                warning="100",
+                critical=None,
             )
 
             command = StateCommand(client, args)
@@ -80,7 +106,7 @@ class TestStateCommandIntegration:
             result = command.execute()
 
             assert result.status == STATE_CRITICAL
-            assert result.message == "lb_down state: DOWN, Health: 0%"
+            assert result.message == "1/1 lbvserver CRITICAL (lb_down)"
 
     def test_state_check_all_lbvservers(self, mock_nitro_server):
         """Test checking all load balancers"""

--- a/tests/mocks/fixtures/stat/lbvserver.json
+++ b/tests/mocks/fixtures/stat/lbvserver.json
@@ -27,7 +27,7 @@
       "state": "UP",
       "actsvcs": 5,
       "inactsvcs": 0,
-      "vslbhealth": 100,
+      "vslbhealth": 95,
       "primaryipaddress": "192.168.1.101",
       "primaryport": 443,
       "totalpktsrecvd": 250000,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,29 @@ class TestArgumentParser:
         assert args.warning == "75"
         assert args.critical == "90"
 
+    def test_lbvserver_health_thresholds(self):
+        """Test lbvserver state command accepts warning and critical health thresholds."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "-H",
+                "192.168.1.1",
+                "-C",
+                "state",
+                "-o",
+                "lbvserver",
+                "-n",
+                "my_vserver",
+                "-w",
+                "95",
+                "-c",
+                "50",
+            ]
+        )
+
+        assert args.warning == "95"
+        assert args.critical == "50"
+
     def test_verbose_flag(self):
         """Test verbose flag (can be repeated)"""
         parser = create_parser()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -62,6 +62,32 @@ class TestNITROSession:
         assert session.port == 8443
         assert session.base_url == "https://192.168.1.1:8443/nitro/v1"
 
+    @patch("check_netscaler.client.session.urllib3.disable_warnings")
+    def test_session_disables_insecure_request_warning(self, mock_disable_warnings):
+        """Test HTTPS sessions with verify_ssl disabled suppress urllib3 warnings."""
+        NITROSession(
+            hostname="192.168.1.1",
+            username="admin",
+            password="secret",
+            ssl=True,
+            verify_ssl=False,
+        )
+
+        mock_disable_warnings.assert_called_once()
+
+    @patch("check_netscaler.client.session.urllib3.disable_warnings")
+    def test_session_keeps_warnings_when_verifying_ssl(self, mock_disable_warnings):
+        """Test verified HTTPS sessions do not suppress urllib3 warnings."""
+        NITROSession(
+            hostname="192.168.1.1",
+            username="admin",
+            password="secret",
+            ssl=True,
+            verify_ssl=True,
+        )
+
+        mock_disable_warnings.assert_not_called()
+
     @patch("requests.Session.post")
     def test_login_success(self, mock_post):
         """Test successful login"""

--- a/tests/test_nagios_output.py
+++ b/tests/test_nagios_output.py
@@ -1,0 +1,30 @@
+"""
+Tests for Nagios output formatting.
+"""
+
+from check_netscaler.output.nagios import NagiosOutput
+
+
+class TestNagiosOutput:
+    """Test Nagios perfdata formatting helpers."""
+
+    def test_format_perfdata_with_threshold_metadata(self):
+        """Perfdata dict items can include threshold metadata."""
+        output = NagiosOutput.format_output(
+            status=0,
+            message="web_lb state: UP, Health: 95%",
+            perfdata={
+                "web_lb.health": {
+                    "value": "95",
+                    "uom": "%",
+                    "warn": "95",
+                    "crit": "80",
+                    "min": "0",
+                    "max": "100",
+                },
+                "total": 1,
+            },
+        )
+
+        assert "'web_lb.health'=95%;95;80;0;100" in output
+        assert "'total'=1;;" in output

--- a/tests/test_perfdata_command.py
+++ b/tests/test_perfdata_command.py
@@ -318,6 +318,35 @@ class TestPerfdataCommand:
         assert "tcpcurclientconn" in result.perfdata
         assert "tcpcurserverconn" in result.perfdata
 
+    def test_ns_connections_summary_message(self):
+        """Test ns perfdata uses a human-readable connection summary."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "ns": {
+                "txmbitsrate": "12.5",
+                "rxmbitsrate": "34.5",
+                "tcpcurclientconnestablished": "123",
+                "tcpcurserverconnestablished": "456",
+                "ssltransactionsrate": "7",
+            }
+        }
+
+        args = self.create_args(
+            objecttype="ns",
+            objectname=(
+                "txmbitsrate,rxmbitsrate,tcpcurclientconnestablished,"
+                "tcpcurserverconnestablished,ssltransactionsrate"
+            ),
+        )
+        command = PerfdataCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_OK
+        assert (
+            result.message
+            == "TX 12.5 MBits/s, RX 34.5 MBits/s, ClientConn 123, ServerConn 456, SSLConn 7 C/s"
+        )
+
     def test_api_error(self):
         """Test when API returns an error"""
         from check_netscaler.client.exceptions import NITROAPIError

--- a/tests/test_state_command.py
+++ b/tests/test_state_command.py
@@ -55,14 +55,20 @@ class TestStateCommand:
     def test_state_single_up(self):
         """Test single object UP"""
         client = self.create_mock_client()
-        client.get_stat.return_value = {"lbvserver": [{"name": "vserver1", "state": "UP"}]}
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 100}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
+        }
 
         args = self.create_args()
         command = StateCommand(client, args)
         result = command.execute()
 
         assert result.status == STATE_OK
-        assert "lbvserver is UP" in result.message
+        assert result.message == "vserver1 state: UP, Health: 100%"
+        assert result.perfdata["health"] == "100%"
 
     def test_state_one_down(self):
         """Test one object DOWN"""
@@ -103,7 +109,7 @@ class TestStateCommand:
         assert result.perfdata["critical"] == 2
 
     def test_state_out_of_service(self):
-        """Test OUT OF SERVICE state (warning)"""
+        """Test lbvserver OUT OF SERVICE state is CRITICAL."""
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [
@@ -116,9 +122,9 @@ class TestStateCommand:
         command = StateCommand(client, args)
         result = command.execute()
 
-        assert result.status == STATE_WARNING
-        assert "1/2 lbvserver WARNING" in result.message
-        assert result.perfdata["warning"] == 1
+        assert result.status == STATE_CRITICAL
+        assert "1/2 lbvserver CRITICAL" in result.message
+        assert result.perfdata["critical"] == 1
 
     def test_state_mixed_statuses(self):
         """Test mix of OK, WARNING, and CRITICAL"""
@@ -238,8 +244,14 @@ class TestStateCommand:
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [
-                {"name": "vserver1", "state": "up"},  # lowercase
-                {"name": "vserver2", "state": "Up"},  # mixed case
+                {"name": "vserver1", "state": "up", "vslbhealth": 100},  # lowercase
+                {"name": "vserver2", "state": "Up", "vslbhealth": 100},  # mixed case
+            ]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [
+                {"name": "vserver1", "effectivestate": "up"},
+                {"name": "vserver2", "effectivestate": "Up"},
             ]
         }
 
@@ -250,18 +262,57 @@ class TestStateCommand:
         assert result.status == STATE_OK
         assert result.perfdata["ok"] == 2
 
+    def test_lbvserver_warns_on_degraded_health(self):
+        """Test lbvserver health below 100 results in WARNING."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
+        }
+
+        args = self.create_args()
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_WARNING
+        assert result.message == "vserver1 state: UP, Health: 95%"
+        assert result.perfdata["health"] == "95%"
+
+    def test_lbvserver_uses_effectivestate_for_status(self):
+        """Test lbvserver effectivestate overrides stat state for status evaluation."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 100}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "DOWN"}]
+        }
+
+        args = self.create_args()
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_CRITICAL
+        assert result.message == "vserver1 state: DOWN, Health: 100%"
+
     def test_backup_vserver_check_disabled_by_default(self):
         """Test that backup check is disabled by default"""
         client = self.create_mock_client()
-        client.get_stat.return_value = {"lbvserver": [{"name": "vs_web", "state": "UP"}]}
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vs_web", "state": "UP", "vslbhealth": 100}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vs_web", "effectivestate": "UP"}]
+        }
 
         args = self.create_args(objecttype="lbvserver", objectname="vs_web")
         command = StateCommand(client, args)
         result = command.execute()
 
-        # Should only call get_stat, not get_config
         assert client.get_stat.called
-        assert not client.get_config.called
+        assert client.get_config.called
         assert result.status == STATE_OK
 
     def test_backup_vserver_active_warning(self):

--- a/tests/test_state_command.py
+++ b/tests/test_state_command.py
@@ -274,9 +274,6 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
-        }
 
         args = self.create_args(warning="100")
         command = StateCommand(client, args)
@@ -294,9 +291,6 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
-        }
 
         args = self.create_args(warning="90", critical="50")
         command = StateCommand(client, args)
@@ -313,9 +307,6 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 40}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
-        }
 
         args = self.create_args(warning="90", critical="50")
         command = StateCommand(client, args)
@@ -329,9 +320,6 @@ class TestStateCommand:
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
-        }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
         }
 
         args = self.create_args(warning="40", critical="50")
@@ -347,9 +335,6 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
-        }
 
         args = self.create_args(warning="abc")
         command = StateCommand(client, args)
@@ -358,22 +343,20 @@ class TestStateCommand:
         assert result.status == STATE_UNKNOWN
         assert "Invalid lbvserver health threshold: abc" in result.message
 
-    def test_lbvserver_uses_effectivestate_for_status_when_health_check_is_enabled(self):
-        """Test lbvserver effectivestate overrides stat state when health checks are enabled."""
+    def test_lbvserver_health_check_uses_stat_state_only(self):
+        """Test lbvserver health checks use stat state without fetching config."""
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 100}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "DOWN"}]
-        }
+        client.get_config.side_effect = AssertionError("get_config should not be called")
 
         args = self.create_args(warning="100")
         command = StateCommand(client, args)
         result = command.execute()
 
-        assert result.status == STATE_CRITICAL
-        assert result.message == "vserver1 state: DOWN, Health: 100%"
+        assert result.status == STATE_OK
+        assert result.message == "vserver1 state: UP, Health: 100%"
 
     def test_backup_vserver_check_disabled_by_default(self):
         """Test that backup check is disabled by default"""
@@ -381,7 +364,6 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vs_web", "state": "UP", "vslbhealth": 100}]
         }
-        client.get_config.return_value = {"lbvserver": [{"name": "vs_web", "effectivestate": "UP"}]}
 
         args = self.create_args(objecttype="lbvserver", objectname="vs_web")
         command = StateCommand(client, args)

--- a/tests/test_state_command.py
+++ b/tests/test_state_command.py
@@ -284,6 +284,7 @@ class TestStateCommand:
         assert result.perfdata["health"]["value"] == "95"
         assert result.perfdata["health"]["warn"] == "100"
         assert result.perfdata["health"]["crit"] == "0"
+        assert "vserver1.health" not in result.perfdata
 
     def test_lbvserver_custom_health_thresholds(self):
         """Test lbvserver health thresholds can be customized with -w/-c."""
@@ -300,6 +301,7 @@ class TestStateCommand:
         assert result.message == "vserver1 state: UP, Health: 95%"
         assert result.perfdata["health"]["warn"] == "90"
         assert result.perfdata["health"]["crit"] == "50"
+        assert "vserver1.health" not in result.perfdata
 
     def test_lbvserver_custom_critical_threshold(self):
         """Test lbvserver health becomes CRITICAL at or below custom critical threshold."""

--- a/tests/test_state_command.py
+++ b/tests/test_state_command.py
@@ -58,20 +58,14 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 100}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
-        }
 
         args = self.create_args()
         command = StateCommand(client, args)
         result = command.execute()
 
         assert result.status == STATE_OK
-        assert result.message == "vserver1 state: UP, Health: 100%"
-        assert result.perfdata["health"]["value"] == "100"
-        assert result.perfdata["health"]["uom"] == "%"
-        assert result.perfdata["health"]["warn"] == "100"
-        assert result.perfdata["health"]["crit"] == "0"
+        assert result.message == "lbvserver is UP"
+        assert "health" not in result.perfdata
 
     def test_state_one_down(self):
         """Test one object DOWN"""
@@ -112,7 +106,7 @@ class TestStateCommand:
         assert result.perfdata["critical"] == 2
 
     def test_state_out_of_service(self):
-        """Test lbvserver OUT OF SERVICE state is CRITICAL."""
+        """Test lbvserver OUT OF SERVICE state remains WARNING by default."""
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [
@@ -125,9 +119,9 @@ class TestStateCommand:
         command = StateCommand(client, args)
         result = command.execute()
 
-        assert result.status == STATE_CRITICAL
-        assert "1/2 lbvserver CRITICAL" in result.message
-        assert result.perfdata["critical"] == 1
+        assert result.status == STATE_WARNING
+        assert "1/2 lbvserver WARNING" in result.message
+        assert result.perfdata["warning"] == 1
 
     def test_state_mixed_statuses(self):
         """Test mix of OK, WARNING, and CRITICAL"""
@@ -251,12 +245,6 @@ class TestStateCommand:
                 {"name": "vserver2", "state": "Up", "vslbhealth": 100},  # mixed case
             ]
         }
-        client.get_config.return_value = {
-            "lbvserver": [
-                {"name": "vserver1", "effectivestate": "up"},
-                {"name": "vserver2", "effectivestate": "Up"},
-            ]
-        }
 
         args = self.create_args()
         command = StateCommand(client, args)
@@ -265,8 +253,23 @@ class TestStateCommand:
         assert result.status == STATE_OK
         assert result.perfdata["ok"] == 2
 
-    def test_lbvserver_warns_on_degraded_health(self):
-        """Test lbvserver health below 100 results in WARNING."""
+    def test_lbvserver_degraded_health_is_ignored_by_default(self):
+        """Test lbvserver health is ignored unless thresholds are provided."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
+        }
+
+        args = self.create_args()
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_OK
+        assert result.message == "lbvserver is UP"
+        assert "health" not in result.perfdata
+
+    def test_lbvserver_warns_on_degraded_health_when_thresholds_are_set(self):
+        """Test lbvserver health below warning threshold results in WARNING."""
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
@@ -275,7 +278,7 @@ class TestStateCommand:
             "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
         }
 
-        args = self.create_args()
+        args = self.create_args(warning="100")
         command = StateCommand(client, args)
         result = command.execute()
 
@@ -355,8 +358,8 @@ class TestStateCommand:
         assert result.status == STATE_UNKNOWN
         assert "Invalid lbvserver health threshold: abc" in result.message
 
-    def test_lbvserver_uses_effectivestate_for_status(self):
-        """Test lbvserver effectivestate overrides stat state for status evaluation."""
+    def test_lbvserver_uses_effectivestate_for_status_when_health_check_is_enabled(self):
+        """Test lbvserver effectivestate overrides stat state when health checks are enabled."""
         client = self.create_mock_client()
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 100}]
@@ -365,7 +368,7 @@ class TestStateCommand:
             "lbvserver": [{"name": "vserver1", "effectivestate": "DOWN"}]
         }
 
-        args = self.create_args()
+        args = self.create_args(warning="100")
         command = StateCommand(client, args)
         result = command.execute()
 
@@ -378,16 +381,14 @@ class TestStateCommand:
         client.get_stat.return_value = {
             "lbvserver": [{"name": "vs_web", "state": "UP", "vslbhealth": 100}]
         }
-        client.get_config.return_value = {
-            "lbvserver": [{"name": "vs_web", "effectivestate": "UP"}]
-        }
+        client.get_config.return_value = {"lbvserver": [{"name": "vs_web", "effectivestate": "UP"}]}
 
         args = self.create_args(objecttype="lbvserver", objectname="vs_web")
         command = StateCommand(client, args)
         result = command.execute()
 
         assert client.get_stat.called
-        assert client.get_config.called
+        assert not client.get_config.called
         assert result.status == STATE_OK
 
     def test_backup_vserver_active_warning(self):

--- a/tests/test_state_command.py
+++ b/tests/test_state_command.py
@@ -68,7 +68,10 @@ class TestStateCommand:
 
         assert result.status == STATE_OK
         assert result.message == "vserver1 state: UP, Health: 100%"
-        assert result.perfdata["health"] == "100%"
+        assert result.perfdata["health"]["value"] == "100"
+        assert result.perfdata["health"]["uom"] == "%"
+        assert result.perfdata["health"]["warn"] == "100"
+        assert result.perfdata["health"]["crit"] == "0"
 
     def test_state_one_down(self):
         """Test one object DOWN"""
@@ -278,7 +281,9 @@ class TestStateCommand:
 
         assert result.status == STATE_WARNING
         assert result.message == "vserver1 state: UP, Health: 95%"
-        assert result.perfdata["health"] == "95%"
+        assert result.perfdata["health"]["value"] == "95"
+        assert result.perfdata["health"]["warn"] == "100"
+        assert result.perfdata["health"]["crit"] == "0"
 
     def test_lbvserver_custom_health_thresholds(self):
         """Test lbvserver health thresholds can be customized with -w/-c."""
@@ -296,6 +301,8 @@ class TestStateCommand:
 
         assert result.status == STATE_OK
         assert result.message == "vserver1 state: UP, Health: 95%"
+        assert result.perfdata["health"]["warn"] == "90"
+        assert result.perfdata["health"]["crit"] == "50"
 
     def test_lbvserver_custom_critical_threshold(self):
         """Test lbvserver health becomes CRITICAL at or below custom critical threshold."""

--- a/tests/test_state_command.py
+++ b/tests/test_state_command.py
@@ -280,6 +280,74 @@ class TestStateCommand:
         assert result.message == "vserver1 state: UP, Health: 95%"
         assert result.perfdata["health"] == "95%"
 
+    def test_lbvserver_custom_health_thresholds(self):
+        """Test lbvserver health thresholds can be customized with -w/-c."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
+        }
+
+        args = self.create_args(warning="90", critical="50")
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_OK
+        assert result.message == "vserver1 state: UP, Health: 95%"
+
+    def test_lbvserver_custom_critical_threshold(self):
+        """Test lbvserver health becomes CRITICAL at or below custom critical threshold."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 40}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
+        }
+
+        args = self.create_args(warning="90", critical="50")
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_CRITICAL
+        assert result.message == "vserver1 state: UP, Health: 40%"
+
+    def test_lbvserver_invalid_threshold_order(self):
+        """Test lbvserver invalid threshold order returns UNKNOWN."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
+        }
+
+        args = self.create_args(warning="40", critical="50")
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_UNKNOWN
+        assert "critical (50) cannot exceed warning (40)" in result.message
+
+    def test_lbvserver_invalid_threshold_value(self):
+        """Test lbvserver invalid threshold values return UNKNOWN."""
+        client = self.create_mock_client()
+        client.get_stat.return_value = {
+            "lbvserver": [{"name": "vserver1", "state": "UP", "vslbhealth": 95}]
+        }
+        client.get_config.return_value = {
+            "lbvserver": [{"name": "vserver1", "effectivestate": "UP"}]
+        }
+
+        args = self.create_args(warning="abc")
+        command = StateCommand(client, args)
+        result = command.execute()
+
+        assert result.status == STATE_UNKNOWN
+        assert "Invalid lbvserver health threshold: abc" in result.message
+
     def test_lbvserver_uses_effectivestate_for_status(self):
         """Test lbvserver effectivestate overrides stat state for status evaluation."""
         client = self.create_mock_client()


### PR DESCRIPTION
## Summary
- add lbvserver state evaluation based on `effectivestate` and health from the NITRO API
- support configurable lbvserver health thresholds with `-w`/`-c` for `state -o lbvserver`
- include health warning/critical values in perfdata output
- suppress `urllib3` insecure-request warnings for intentionally unverified HTTPS sessions

## Why
This brings the Python 3 `check_netscaler` behavior closer to legacy `check_ns_vserver.py` deployments while keeping the newer command structure:
- `effectivestate != UP` => CRITICAL
- health `<= critical` => CRITICAL
- health `< warning` => WARNING
- health `>= warning` => OK

With no explicit `-w/-c`, the behavior remains legacy-compatible for lbvserver health checks:
- warning below `100`
- critical at or below `0`

## Examples
```bash
check_netscaler -H HOST -u USER -p PASS -C state -o lbvserver -n VSERVER
check_netscaler -H HOST -u USER -p PASS -C state -o lbvserver -n VSERVER -w 95 -c 80
```

## Notes
- perfdata now includes thresholds for lbvserver health, for example:
  - `'web_lb.health'=95%;95;80;0;100`
- targeted tests were added/updated for state handling, CLI parsing, output formatting, and integration cases
